### PR TITLE
fix: remove TestCase inheritance to allow consistent method resolution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+Changed
+_______
+* Remove TestCase inheritance from OpenEdxTestMixin.
 
 [0.5.0] - 2021-08-24
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openedx_events/tests/utils.py
+++ b/openedx_events/tests/utils.py
@@ -1,8 +1,6 @@
 """
 Utils used by Open edX events.
 """
-from django.test import TestCase
-
 from openedx_events.tooling import OpenEdxPublicSignal
 
 
@@ -48,15 +46,17 @@ class EventsIsolationMixin:
             event.enable()
 
 
-class OpenEdxEventsTestCase(EventsIsolationMixin, TestCase):
+class OpenEdxEventsTestMixin(EventsIsolationMixin):
     """
     A mixin to be used by TestCases that want to isolate their use of Open edX Events.
 
     Example usage:
 
-        class MyTestCase(OpenEdxEventsTestCase):
+        class MyTestCase(TestCase, OpenEdxEventsTestCase):
 
             ENABLED_OPENEDX_EVENTS = ['org.openedx.learning.student.registration.completed.v1']
+
+    This class assumes that's it's being used in conjunction TestCase or TestCase subclasses.
     """
 
     ENABLED_OPENEDX_EVENTS = []
@@ -66,7 +66,7 @@ class OpenEdxEventsTestCase(EventsIsolationMixin, TestCase):
         """
         Start events isolation for class.
         """
-        super().setUpClass()
+        super().setUpClass()  # pylint: disable=no-member
         cls().start_events_isolation()
 
     @classmethod


### PR DESCRIPTION
**Description:** 

This change allows using the class with other classes that inherit from TestCase, avoiding this type of error:

```
openedx/core/djangoapps/user_authn/views/tests/test_register.py:2218: in <module>
    class TestFacebookRegistrationView(
E   TypeError: Cannot create a consistent method resolution
E   order (MRO) for bases OpenEdxEventsTestCase, object, TransactionTestCase
```
