### PR TITLE
Modify avroattrsbridge to work with signal classes instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/openedx_events.*.rst
 # Private requirements
 requirements/private.in
 requirements/private.txt
+
+# IDA cruft
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ----------
+Changed
+~~~~~~~
+* Updated AvroAttrsBridge to create schemas from entire signals rather than individual attrs classes
 
 [0.8.2] - 2022-04-13
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Unreleased
 ----------
 Changed
 ~~~~~~~
-* Updated AvroAttrsBridge to create schemas from entire signals rather than individual attrs classes
+* Updated AvroAttrsBridge to create schemas from signal data dict rather than individual attrs classes
 
 [0.8.2] - 2022-04-13
 --------------------

--- a/docs/decisions/0004-external-event-bus-and-django-signal-events.rst
+++ b/docs/decisions/0004-external-event-bus-and-django-signal-events.rst
@@ -15,19 +15,20 @@ The purpose of this ADR is to better define the relationship between the existin
 
 Decision
 --------
+Note that for purposes of this ADR, ``event`` refers to a dictionary of data that is emitted by a Django signal, specifically by an instance of ``OpenEdxPublicSignal``
 
 - Event definitions will be shared between internal and external events. The event definitions will continue to be in the form of ``OpenEdxPublicSignal``, as decided in ADR ":doc:`0003-events-payload`".
 
-- At this time, event bus events will be triggered from a Django signal handler of the Django signal representing the corresponding internal event.
+- At this time, events will be published to the event bus from a Django signal handler. That is, when an internal event is sent via a Django signal, one of the handlers will take the event and publish it to the event bus.
 
-- The Django signal must contain all of the necessary details to serialize the event and send it across the event bus, such that it can be deserialized and converted back into the ``OpenEdxPublicSignal`` again on the consumer side.
+- The Django signal must contain all of the necessary details to serialize events and send them across the event bus, such that they can be deserialized and sent by the same instance of ``OpenEdxPublicSignal`` again on the consumer side.
 
-- For consumption, the event bus implementation will convert the messages back into Django signals and emit them within the consumer application.
+- For consumption, the event bus implementation will look up the correct ``OpenEdxPublicSignal`` from the deserialized event metadata and use it to emit the deserialized event within the consumer application.
 
 Consequences
 ------------
 
-- The ``OpenEdxPublicSignal`` serves as the event definition, and doubles as a Django signal, for both internal and external events. In other words, the ``OpenEdxPublicSignal`` provides the schema for external events.
+- The ``OpenEdxPublicSignal`` serves as the event definition, and doubles as a Django signal, for both internal and external events. In other words, an instance of ``OpenEdxPublicSignal`` provides the schema for the events it can emit
 
 - An external event will never be sent without a corresponding internal event (at this time, based on the current design).
 
@@ -37,14 +38,12 @@ Consequences
 
 - It is unclear whether the use of an extra layer of signals when sending/consuming external events will cause difficulties for implementations. If so, we may need to adjust and document when and where an alternative approach should be taken.
 
-- The data definition in ``OpenEdxPublicSignal`` is geared toward signals, where the top-level dict represents keyword arguments emitted to the signal. This definition is not designed for event bus events, except in that it could be converted back to a signal.
-
 Rejected Alternatives
 ---------------------
 
-- Sending external event at same place of code as the internal Signal is sent. Decided that this is more complex than we need, and we can add this later if it becomes necessary.
+- Sending external event at same place of code as the internal event is sent. Decided that this is more complex than we need, and we can add this later if it becomes necessary.
 
-- Sending external events without a corresponding internal event. This might be useful for Event Sourcing, and is not being ruled out forever, but is not currently being designed for.
+- Sending external events without a corresponding internal event. This might be useful for event sourcing, and is not being ruled out forever, but is not currently being designed for.
 
 Additional Resources
 --------------------

--- a/docs/decisions/0005-external-event-schema-format.rst
+++ b/docs/decisions/0005-external-event-schema-format.rst
@@ -25,13 +25,16 @@ Context
 Decision
 --------
 
-* We will continue using ``attrs`` decorated classes for explicit schema definition.
+* We will continue favoring ``attrs`` decorated classes for explicit schema definitions for signals
 
 * We will also use the binary serialization of messages that are transmitted over the event bus.
 
 * The binary encoding of messages will use AVRO specification.
 
-* A new utility will be created to auto generate Avro schema based on ``attrs`` decorated classes.
+* A new utility will be created to auto generate Avro schema from the ``init_dict`` property of an OpenEdxPublicSignal instance
+
+  * Out of the box, bridge will generate schemas for ``attrs`` decorated classes and Avro primitives
+  * Developers will be able to create extensions to the bridge to make it handle non-attrs, non-primitive classes
 
 Implementation Notes
 --------------------
@@ -46,7 +49,7 @@ Consequences
 
 * There will be bridging code that will abstract away schema generation from most developers of events.  This may have a negative impact as it might make it harder for developers to reason about schema evolution.
 
-* For non primitive types (eg. Opaque Keys objects), the bridging code between ``Avro`` and ``attrs`` will need to have special serializers or clearly fail.
+* For non-primitive, non-attr types (eg. Opaque Keys objects), the bridging code between will need to have special serializers or clearly fail.
 
 * Any reference to using JSON or JSONSchema in `OEP-41: Asynchronous Server Event Message Format`_ should be review and updated to clarify implied or explicit decisions that may be reversed by this decision.
 

--- a/docs/how_tos/avro_attrs_bridge.rst
+++ b/docs/how_tos/avro_attrs_bridge.rst
@@ -5,56 +5,52 @@ Purpose
 -------
 Used to automate the following conversions:
 
-attrs class => Avro Dict => Bytes
-Bytes => Avro Dict => attrs class
+event data => Avro dict => bytes
+bytes => Avro dict => event data
 
 Essentially, helps serialize and deserialize events data specified in openedx-events repository.
 
 How To Use
 ----------
-
-If you want to go from attrs obj to serialized bytes and back:
-
-.. code-block:: python
-
-   from openedx_events.learning.data import UserData
-   from openedx_events.avro_attrs_bridge import AvroAttrsBridge
-
-   config = {
-        "source": "/openedx/lms/web",
-        "sourcehost": "edx.devstack.lms",
-        "type": "org.openedx.learning.student.registration.completed.v1",
-    }
-
-   user_data_bridge = AvroAttrsBridge(AvroAttrsBridge, config)
-   user_data_object = UserData(...) # create object
-   serialied_user_data = user_data_bridge.serialize(user_data_object)
-   deserialize_user_data = user_data_bridge.deserealize(serialied_user_data)
-   assert deserealize_user_data == user_data_object
-
-
-
-To learn more about what is in config, see Fields in `OEP 41`_:Asynchronous Server Event Message Format.
-
-.. _OEP 41: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0041-arch-async-server-event-messaging.html#fields
-
-
-If you want to go from attrs obj to avro dict and back:
+To instantiate a bridge for a new signal
 
 .. code-block:: python
 
-   from openedx_events.learning.data import UserData
-   from openedx_events.avro_attrs_bridge import AvroAttrsBridge
+    USER_SIGNAL = OpenEdxPublicSignal(
+        event_type="simple.signal",
+        data={"user": UserData}
+    )
+    user_data_bridge = AvroAttrsBridge(USER_SIGNAL)
 
-   config = {
-        "source": "/openedx/lms/web",
-        "sourcehost": "edx.devstack.lms",
-        "type": "org.openedx.learning.student.registration.completed.v1",
-    }
+_OEP 41: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0041-arch-async-server-event-messaging.html#fields
 
-   user_data_bridge = AvroAttrsBridge(AvroAttrsBridge, config)
-   user_data_object = UserData(...) # create object
-   user_data_dict = user_data_bridge.to_dict(user_data_object)
-   user_data_new_object = user_data_bridge.dict_to_attrs(user_data_dict)
-   assert deserealize_user_data == user_data_new_object
+You can then use the ``from_dict`` and ``to_dict`` methods on the bridge,
+as well as the ``schema_dict`` property to configure an Avro-based de/serializer
+to correctly serialize and deserialize events to be sent by the signal.
+
+For example, to serialize a COURSE_ENROLLMENT_CREATED event (eventually to
+be published to the event bus)
+
+.. code-block:: python
+
+   enrollment_bridge = AvroAttrsBridge(COURSE_ENROLLMENT_CREATED)
+   enrollment_object = CourseEnrollmentData(...enrollment_data)
+   out = io.BytesIO()
+   data_dict = enrollment_bridge.to_dict({"enrollment": enrollment_object})
+   fastavro.schemaless_writer(out, bridge.schema_dict, data_dict)
+   out.seek(0)
+   return out.read()
+
+To deserialize bytes that have come over the wire on the event bus, and then
+emit the event to the relevant listeners, you will need to know the event_type
+of the original signal. This can be sent over as a message header or event
+topic or other metadata, depending on the bus implementation.
+
+.. code-block:: python
+
+   my_signal = OpenEdxPublicSignal.get_signal_by_type(get_event_type())
+   bridge = AvroAttrsBridge(my_signal)
+   data_file = io.BytesIO(bytes_from_wire)
+   as_dict = fastavro.schemaless_reader(data_file, bridge.schema_dict)
+   my_signal.send_event(**bridge.from_dict(as_dict))
 

--- a/openedx_events/bridge/avro_attrs_bridge.py
+++ b/openedx_events/bridge/avro_attrs_bridge.py
@@ -1,76 +1,59 @@
 """
-Code to convert attr classes to avro specification.
+Code to convert attr classes to Avro specification.
+
+TODO (EventBus): handle optional parameters and allow for schema evolution (ARCHBOM-2013)
 """
-import io
 import json
-import uuid
-from datetime import datetime
 from typing import Any, Dict
 
 import attr
 import fastavro
 
-from openedx_events.bridge.avro_attrs_bridge_extensions import DatetimeAvroAttrsBridgeExtension
-from openedx_events.bridge.avro_types import AVRO_TYPE_FOR
+from openedx_events.bridge.avro_attrs_bridge_extensions import (
+    CourseKeyAvroAttrsBridgeExtension,
+    DatetimeAvroAttrsBridgeExtension,
+)
+from openedx_events.bridge.avro_types import PYTHON_TYPE_TO_AVRO_MAPPING
 
 
 class AvroAttrsBridge:
     """
-    Use to convert between Avro and Attrs data specifications.
+    Convert between Avro and OpenEdxPublicSignal data specifications.
 
-    Intended usecase: To abstract serilalization and deserialization of openedx-events to send over pulsar or kafka
+    Intended use: To abstract serialization and deserialization of openedx-events to send over an event bus
+    The bridge can be used to both automatically generate an Avro schema for the events sent by the associated
+    signal instance and to serialize the events themselves using the generated schema.
+    TODO (EventBus): rename this class and file to convey that the bridge now works with entire signal
+    definitions rather than just attrs classes (ARCHBOM-2101)
     """
 
-    # default extensions, can be overwriteen by passing in extensions during obj initialization
+    # default extensions, can be overwritten by passing in extensions during obj initialization
     default_extensions = {
-        DatetimeAvroAttrsBridgeExtension.cls: DatetimeAvroAttrsBridgeExtension()
-    }
-    # default config, should be overwritten by passing in config during obj initialization
-    default_config = {
-        "source": "/openedx/unknown/avro_attrs_bridge",
-        "sourcehost": "unknown",
-        "type": "org.openedx.test.test.test.v0",
+        DatetimeAvroAttrsBridgeExtension.cls: DatetimeAvroAttrsBridgeExtension(),
+        CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
     }
 
-    def __init__(self, attrs_cls, extensions=None, config=None):
+    def __init__(self, signal, extensions=None):
         """
         Init method for Avro Attrs Bridge.
 
         Arguments:
-            attrs_cls: Attr Class Object (not instance)
-            extensions: dict mapping Class Object to its AvroAttrsBridgeExtention subclass instance
-            config: dict with followings keys
-                - source:  This field will be used to indicate the logical source of an event, and will be of the form
-                           /{namespace}/{service}/{web|worker}.
-                           All services in standard distribution of Open edX should use openedx for the namespace.
-                           Examples of services might be “discovery”, “lms”, “studio”, etc.
-                           The value “web” will be used for events emitted by the web application,
-                           and “worker” will be used for events emitted by asynchronous tasks such as celery workers.
-                           For more info, see OEP-41: Asynchronous Server Event Message Format
-                - sourcehost: should represent the physical source of message
-                               -- i.e. host identifier of the server that emitted this event (example: edx.devstack.lms)
-                              For more info, see OEP-41: Asynchronous Server Event Message Format
-                - type: The name of event.
-                        Should be formatted `{Reverse DNS}.{Architecture Subdomain}.{Subject}.{Action}.{Major Version}`.
-                        For more info, see OEP-41: Asynchronous Server Event Message Format
+            signal: An instance of OpenEdxPublicSignal
+            extensions: dict mapping a Class to an instance of the required AvroAttrsBridgeExtension subclass, eg
+                       { MyDataClass : MyDataClassAvroAttrsBridgeExtension() }
         """
-        self._attrs_cls = attrs_cls
-
         self.extensions = {}
         self.extensions.update(self.default_extensions)
         if isinstance(extensions, dict):
             self.extensions.update(extensions)
 
-        self.config = {}
-        self.config.update(self.default_config)
-        if isinstance(config, dict):
-            self.config.update(config)
-
-        # Used by record_field_for_attrs_class function to keep track of which
+        self._signal = signal
+        # Used by _create_avro_field_definition function to keep track of which
         # records have already been defined in schema.
-        # Reason: fastavro does no allow you to define record with same name twice
+        # Reason: fastavro does not allow you to define record with same name twice
         self.schema_record_names = set()
-        self.schema_dict = self._attrs_to_avro_schema(attrs_cls)
+        self.schema_dict = self._avro_schema_dict_from_signal()
+
         # make sure the schema is parsable
         fastavro.parse_schema(self.schema_dict)
 
@@ -78,176 +61,171 @@ class AvroAttrsBridge:
         """Json dumps schema dict into a string."""
         return json.dumps(self.schema_dict, sort_keys=True)
 
-    def _attrs_to_avro_schema(self, attrs_cls):
+    def _avro_schema_dict_from_signal(self):
         """
-        Generate avro schema for attr_cls.
+        Generate the Avro schema for events sent by self._signal.
 
-        Arguments:
-            attrs_cls: Attr class object
+        TODO (EventBus): Include required CloudEvent fields with sensible defaults
         Returns:
-            complex dict that defines avro schema for attrs_cls
+            complex dict that defines Avro schema for events sent by self._signal
         """
         base_schema = {
-            "namespace": "io.cloudevents",
-            "type": "record",
             "name": "CloudEvent",
-            "version": "1.0",
+            "type": "record",
             "doc": "Avro Event Format for CloudEvents created with openedx_events/avro_attrs_bridge",
-            "fields": [
-                {"name": "id", "type": "string"},
-                {"name": "type", "type": "string"},
-                {"name": "specversion", "type": "string", "default": "1.0"},
-                {"name": "time", "type": "string"},
-                {"name": "source", "type": "string"},
-                {"name": "sourcehost", "type": "string"},
-                {"name": "minorversion", "type": "int"},
-            ],
+            "fields": [],
         }
 
-        record_fields = self._record_fields_for_attrs_class(attrs_cls)
-        base_schema["fields"].append(record_fields)
+        for data_key, data_type in self._signal.init_data.items():
+            base_schema["fields"].append(self._create_avro_field_definition(data_key, data_type))
         return base_schema
 
-    def _record_fields_for_attrs_class(
-        self, attrs_class, field_name: str = "data"
+    def _create_avro_field_definition(self, data_key, data_type):
+        """
+        Create an Avro schema field definition from a data definition.
+
+        Arguments:
+            data_key: Field name
+            data_type: Python data type, eg `str`, `CourseKey`, `CourseEnrollmentData`
+        """
+        # Case 1: data_type has known extension
+        if extension := self.extensions.get(data_type, None):
+            return {
+                "name": data_key,
+                "type": extension.record_fields(),
+            }
+        # Case 2: data_type is a simple type that can be converted directly to an Avro type
+        elif data_type in PYTHON_TYPE_TO_AVRO_MAPPING:
+            if PYTHON_TYPE_TO_AVRO_MAPPING[data_type] in ["record", "array"]:
+                # TODO (EventBus): figure out how to handle container types (dicts and arrays). (ARCHBOM-2095)
+                raise Exception("Unable to generate Avro schema for dict or array fields")
+            return {
+                "name": data_key,
+                "type": PYTHON_TYPE_TO_AVRO_MAPPING[data_type],
+            }
+
+        # Case 2: data_type is an attrs class
+        elif hasattr(data_type, "__attrs_attrs__"):
+            # Inner Attrs Class
+
+            # fastavro does not allow you to redefine the same record type more than once,
+            # so only define an attr record once
+            if data_type.__name__ in self.schema_record_names:
+                return {
+                    "name": data_key,
+                    "type": data_type.__name__,
+                }
+            else:
+                self.schema_record_names.add(data_type.__name__)
+                return self._generate_avro_record_for_attrs_class(
+                    data_type, data_key
+                )
+        else:
+            raise TypeError(
+                f"Data type {data_type} is not supported by AvroAttrsBridge. The data type needs to either"
+                " be one of the types in PYTHON_TYPE_TO_AVRO_MAPPING, an attrs decorated class, or one of the types"
+                " defined in self.extensions."
+            )
+
+    def _generate_avro_record_for_attrs_class(
+        self, attrs_class, field_name: str
     ) -> Dict[str, Any]:
         """
-        Generate avro record for attrs_class.
+        Generate Avro record for attrs_class.
 
-        Will also recursively generate avro records for any sub attr classes and any custom types.
+        Will also recursively generate Avro records for any sub attr classes and any custom types.
 
-        Custom types are handled by AvroAttrsBridgeExtention subclass instance values defined in self.extensions dict
+        Custom types are handled by AvroAttrsBridgeExtension subclass instance values defined in self.extensions dict
         """
         field: Dict[str, Any] = {}
         field["name"] = field_name
         field["type"] = dict(name=attrs_class.__name__, type="record", fields=[])
 
         for attribute in attrs_class.__attrs_attrs__:
-            # Attribute is a simple type.
-            if attribute.type in AVRO_TYPE_FOR:
-                inner_field = {
-                    "name": attribute.name,
-                    "type": AVRO_TYPE_FOR[attribute.type],
-                }
-
-            # Attribute is another attrs class
-            elif hasattr(attribute.type, "__attrs_attrs__"):
-                # Inner Attrs Class
-
-                # fastavro does not allow you to redefine the same record type more than once,
-                # so only define an attr record once
-                if attribute.type.__name__ in self.schema_record_names:
-                    inner_field = {
-                        "name": attribute.name,
-                        "type": attribute.type.__name__,
-                    }
-                else:
-                    self.schema_record_names.add(attribute.type.__name__)
-                    inner_field = self._record_fields_for_attrs_class(
-                        attribute.type, attribute.name
-                    )
-            # else attribute is an costom type and
-            # there needs to be AvroAttrsBridgeExtension for attribute in self.extensions
-            else:
-                inner_field = None
-                extension = self.extensions.get(attribute.type)
-                if extension is not None:
-                    inner_field = {
-                        "name": attribute.name,
-                        "type": extension.record_fields(),
-                    }
-                else:
-                    raise TypeError(
-                        f"AvroAttrsBridgeExtension for {attribute.type} not in self.extensions."
-                    )
-            # Assume attribute is optional if it has a default value
-            # The default value is always set to None to allow attr class to handle dealing with default values
-            # in dict_to_attrs function in this class
-            if attribute.default is not attr.NOTHING:
-                inner_field["type"] = ["null", inner_field["type"]]
-                inner_field["default"] = None
-            field["type"]["fields"].append(inner_field)
-
+            field["type"]["fields"].append(
+                self._create_avro_field_definition(attribute.name, attribute.type)
+            )
         return field
 
-    def to_dict(self, obj, event_overrides=None):
+    def to_dict(self, event_data):
         """
-        Convert obj into dictionary that matches avro schema (self.schema).
+        Convert event_data into dictionary that matches Avro schema (self.schema).
 
-        Args:
-            obj: instance of self._attr_cls
-            event_overrides: dict with following value overwrites:
-                - id: unique id for this event. If id is not in dict, a uuid1 will be created for this event
-                      For more info, see OEP-41: Asynchronous Server Event Message Format
-                - time: time stamp for this event. If time is not in dict, datetime.now() will be called
-                        For more info, see OEP-41: Asynchronous Server Event Message Format
+        Warning: this does not validate that the data_dict input matches self._signal
+
+        Arguments:
+            event_data: dict with all the values specified in OpenEdxPublicSignal.init_data.
         """
-        if isinstance(event_overrides, dict) and "id" in event_overrides:
-            event_id = event_overrides["id"]
-        else:
-            event_id = str(uuid.uuid1())
-        if isinstance(event_overrides, dict) and "time" in event_overrides:
-            event_timestamp = event_overrides["time"]
-        else:
-            event_timestamp = datetime.now().isoformat()
-        obj_as_dict = attr.asdict(obj, value_serializer=self._extension_serializer)
-        # Not sure if it makes sense to keep version info here since the schema registry will actually
-        # keep track of versions and the topic can have only one associated schema at a time.
-        avro_record = dict(
-            id=event_id,
-            type=self.config["type"],
-            time=event_timestamp,
-            source=self.config["source"],
-            sourcehost=self.config["sourcehost"],
-            minorversion=0,
-            data=obj_as_dict,
+        # TODO (EventBus): is there better way to do this besides using json?
+        # This first converts data_dict to json string and then back to dict.
+
+        return json.loads(
+            json.dumps(
+                event_data, sort_keys=True, default=self._event_value_to_json
+            )
         )
-        return avro_record
 
-    def serialize(self, obj) -> bytes:
+    def _event_value_to_json(self, value):
         """
-        Convert from attrs to a valid avro record.
+        Serialize a top-level value in an event data dictionary to match the Avro schema.
         """
-        avro_record = self.to_dict(obj)
-        # Try to serialize using the generated schema.
-        out = io.BytesIO()
-        fastavro.schemaless_writer(out, self.schema_dict, avro_record)
-        out.seek(0)
-        return out.read()
+        # Case 1: Value is an instance of an attrs-decorated class
+        if hasattr(value, "__attrs_attrs__"):
+            return attr.asdict(value, value_serializer=self._serialize_non_attrs_instance)
+        # Case 2: Value is an instance of a class (or subclass) for which the bridge has a known extension
+        for extended_class, extension in self.extensions.items():
+            if issubclass(type(value), extended_class):
+                return extension.serialize(value)
+        # Case 3: Default
+        return value
 
-    def _extension_serializer(self, _, field, value):
+    def _serialize_non_attrs_instance(self, _, field, value):
         """
-        Pass this callback into attrs.asdict function as "value_serializer" arg.
+        Use an extension to serialize a value of the appropriate class.
 
-        Serializes values for which an extention exists in self.extensions dict.
+        Used as a callback to attr.asdict to handle any inner fields that are not attrs classes or primitives
         """
         extension = self.extensions.get(field.type, None)
         if extension is not None:
             return extension.serialize(value)
         return value
 
-    def deserialize(self, data: bytes, writer_schema=None) -> object:
+    def from_dict(self, data: dict):
         """
-        Deserialize data into self.attrs_cls instance.
+        Convert dict into event data that can be sent with self._signal.
 
-        Args:
-            data: bytes that you want to deserialize
-            writer_schema: pass the schema used to serialize data if it is differnt from current schema
-        """
-        data_file = io.BytesIO(data)
-        if writer_schema is not None:
-            record = fastavro.schemaless_reader(
-                data_file, writer_schema, self.schema_dict
-            )
-        else:
-            record = fastavro.schemaless_reader(data_file, self.schema_dict)
-        return self.dict_to_attrs(record["data"], self._attrs_cls)
+        Arguments:
+            data: Dictionary returned from AvroDeserializer
 
-    def dict_to_attrs(self, data: dict, attrs_cls):
+        Returns:
+            dict: Event data dictionary
         """
-        Convert data into instantiated object of attrs_cls.
+        return dict([(data_key, self._deserialized_avro_dict_to_object(data[data_key], data_type))
+                     for data_key, data_type in self._signal.init_data.items()])
+
+    def _deserialized_avro_dict_to_object(self, data: dict, data_type):
         """
-        for attribute in attrs_cls.__attrs_attrs__:
+        Convert dictionary entry into an instance of data_type.
+
+        Used to convert messages from an AvroDeserializer into events that can be sent by the
+        appropriate signal instance
+
+        Arguments:
+            data: Dictionary returned from AvroDeserializer
+            data_type: Desired Python data type, eg `str`, `CourseKey`, `CourseEnrollmentData`
+
+        Returns:
+            An instance of data_type
+        """
+        if not hasattr(data_type, '__attrs_attrs__'):
+            if extension := self.extensions.get(data_type, None):
+                return extension.deserialize(data)
+            else:
+                raise TypeError(
+                    f"Unable to deserialize {data_type} data, please add extension for custom data type"
+                )
+
+        for attribute in data_type.__attrs_attrs__:
             if attribute.name in data:
                 sub_data = data[attribute.name]
                 if sub_data is None:
@@ -258,7 +236,7 @@ class AvroAttrsBridge:
                 else:
                     if hasattr(attribute.type, "__attrs_attrs__"):
                         if attribute.name in data:
-                            data[attribute.name] = self.dict_to_attrs(
+                            data[attribute.name] = self._deserialized_avro_dict_to_object(
                                 sub_data, attribute.type
                             )
                     elif attribute.type in self.extensions:
@@ -269,27 +247,9 @@ class AvroAttrsBridge:
                             raise Exception(
                                 f"Necessary key: {attribute.name} not found in data dict"
                             )
-                    elif attribute.type not in AVRO_TYPE_FOR:
+                    elif attribute.type not in PYTHON_TYPE_TO_AVRO_MAPPING:
                         raise TypeError(
                             f"Unable to deserialize {attribute.type} data, please add extension for custom data type"
                         )
 
-        return attrs_cls(**data)
-
-
-class AvroAttrsBridgeKafkaWrapper(AvroAttrsBridge):
-    """
-    Wrapper class to help AvroAttrsBridge to work with kafka.
-    """
-
-    def to_dict(self, obj, _kafka_context):  # pylint: disable=signature-differs
-        """
-        Pass this function as callable input to confluent_kafka::AvroSerializer.
-        """
-        return super().to_dict(obj)
-
-    def from_dict(self, data, _kafka_context):
-        """
-        Pass this function as callable input to confluent_kafka::AvroDeSerializer.
-        """
-        return self.dict_to_attrs(data["data"], self._attrs_cls)
+        return data_type(**data)

--- a/openedx_events/bridge/avro_attrs_bridge.py
+++ b/openedx_events/bridge/avro_attrs_bridge.py
@@ -82,7 +82,7 @@ class AvroAttrsBridge:
 
     def _create_avro_field_definition(self, data_key, data_type):
         """
-        Create an Avro schema field definition from a data definition.
+        Create an Avro schema field definition from an OpenEdxPublicSignal data definition.
 
         Arguments:
             data_key: Field name

--- a/openedx_events/bridge/avro_attrs_bridge_extensions.py
+++ b/openedx_events/bridge/avro_attrs_bridge_extensions.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from opaque_keys.edx.keys import CourseKey
 
-from openedx_events.bridge.avro_types import AVRO_TYPE_FOR
+from openedx_events.bridge.avro_types import PYTHON_TYPE_TO_AVRO_MAPPING
 
 
 class AvroAttrsBridgeExtention(ABC):
@@ -17,32 +17,32 @@ class AvroAttrsBridgeExtention(ABC):
     cls: type
 
     def type(self):
-        """Get type of class this extension serilizer and deserializes."""
+        """Get type of class this extension serializer and deserializes."""
         return type(self.cls)
 
     @abstractmethod
     def serialize(self, obj) -> str:
-        """Abstart method to serialize obj into string."""
+        """Abstract method to serialize obj into string."""
         ...
 
     @abstractmethod
     def deserialize(self, data: str) -> object:
-        """Abstart method to deserialize string array into obj."""
+        """Abstract method to deserialize string array into obj."""
         ...
 
     @abstractmethod
     def record_fields(self):
         """
-        Abstract method to define avro schema for self.cls.
+        Abstract method to define Avro schema for self.cls.
 
-        This is usually just a AVRO_TYPE_FOR[str]
+        This is usually just a PYTHON_TYPE_TO_AVRO_MAPPING[str]
         """
         ...
 
 
 class CourseKeyAvroAttrsBridgeExtension(AvroAttrsBridgeExtention):
     """
-    AvroAttrsBrdgeExtension for CourseKey class.
+    AvroAttrsBridgeExtension for CourseKey class.
     """
 
     cls = CourseKey
@@ -56,13 +56,17 @@ class CourseKeyAvroAttrsBridgeExtension(AvroAttrsBridgeExtention):
         return CourseKey.from_string(data)
 
     def record_fields(self):
-        """Define avro schema for self.cls."""
-        return AVRO_TYPE_FOR[str]
+        """Define Avro schema for self.cls."""
+        return PYTHON_TYPE_TO_AVRO_MAPPING[str]
 
 
 class DatetimeAvroAttrsBridgeExtension(AvroAttrsBridgeExtention):
     """
-    AvroAttrsBrdgeExtension for CourseKey class.
+    AvroAttrsBridgeExtension for datetime class.
+
+    Note the choice of an iso-formatted string comes directly from the required CloudEvent <-> Avro mapping
+    specified here:
+     https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/avro-format.md#21-type-system-mapping
     """
 
     cls = datetime
@@ -76,5 +80,5 @@ class DatetimeAvroAttrsBridgeExtension(AvroAttrsBridgeExtention):
         return datetime.fromisoformat(data)
 
     def record_fields(self):
-        """Define avro schema for self.cls."""
-        return AVRO_TYPE_FOR[str]
+        """Define Avro schema for self.cls."""
+        return PYTHON_TYPE_TO_AVRO_MAPPING[str]

--- a/openedx_events/bridge/avro_types.py
+++ b/openedx_events/bridge/avro_types.py
@@ -1,5 +1,5 @@
-"""A mapping of python types to the avro type that we want to use make valid avro schema."""
-AVRO_TYPE_FOR = {
+"""A mapping of python types to the Avro type that we want to use make valid avro schema."""
+PYTHON_TYPE_TO_AVRO_MAPPING = {
     None: "null",
     bool: "boolean",
     int: "long",

--- a/openedx_events/bridge/tests/test_avro_attrs_bridge.py
+++ b/openedx_events/bridge/tests/test_avro_attrs_bridge.py
@@ -4,334 +4,276 @@ Tests for AvroAttrsBridge.
 from datetime import datetime
 from unittest import TestCase
 
-import attr
 from opaque_keys.edx.keys import CourseKey
 
 from openedx_events.bridge.avro_attrs_bridge import AvroAttrsBridge
-from openedx_events.bridge.avro_attrs_bridge_extensions import CourseKeyAvroAttrsBridgeExtension
-from openedx_events.learning.data import CourseData, CourseEnrollmentData, UserData, UserPersonalData
+from openedx_events.bridge.tests.test_utilities import (
+    NonAttrs,
+    SimpleAttrs,
+    SimpleBridgeExtension,
+    SubTestData0,
+    SubTestData1,
+    TestData,
+    create_simple_signal,
+    deserialize_bytes_to_event_data,
+    serialize_event_data_to_bytes,
+)
 
 
-class TestNoneBaseTypesInBridge(TestCase):
+class TestAvroAttrsBridge(TestCase):
     """
-    Tests to make sure AttrsAvroBridge handles custom types correctly.
+    Test AvroAttrsBridge functionality
     """
 
-    def setUp(self):
-        super().setUp()
-        user_personal_data = UserPersonalData(
-            username="username", email="email", name="name"
-        )
-        user_data = UserData(id=1, is_active=True, pii=user_personal_data)
-        # define Coursedata, which needs Coursekey, which needs opaque key
-        course_id = "course-v1:edX+DemoX.1+2014"
-        course_key = CourseKey.from_string(course_id)
-        course_data = CourseData(
-            course_key=course_key,
-            display_name="display_name",
-            start=datetime.now(),
-            end=datetime.now(),
-        )
-        self.course_enrollment_data = CourseEnrollmentData(
-            user=user_data,
-            course=course_data,
-            mode="mode",
-            is_active=False,
-            creation_date=datetime.now(),
-            created_by=user_data,
-        )
+    def setUp(self) -> None:
+        self.maxDiff = None
 
-    def test_non_base_types_in_bridge(self):
+    def test_simple_schema_generation(self):
+        SIGNAL = create_simple_signal({"event_data": SimpleAttrs})
+
+        bridge = AvroAttrsBridge(SIGNAL)
+        expected_dict = {
+            "type": "record",
+            "name": "CloudEvent",
+            "doc": "Avro Event Format for CloudEvents created with openedx_events/avro_attrs_bridge",
+            "fields": [
+                {"name": "event_data", "type":
+                    {"name": "SimpleAttrs", "type": "record", "fields": [
+                        {"name": "boolean_field", "type": "boolean"},
+                        {"name": "int_field", "type": "long"},
+                        {"name": "float_field", "type": "double"},
+                        {"name": "bytes_field", "type": "bytes"},
+                        {"name": "string_field", "type": "string"},
+                    ]
+                     }
+                 }
+            ],
+        }
+
+        self.assertDictEqual(bridge.schema_dict, expected_dict)
+
+    def test_nested_attrs_object_serialization(self):
+        SIGNAL = create_simple_signal({"test_data": TestData})
+        bridge = AvroAttrsBridge(SIGNAL)
+
+        expected_dict = {
+            "type": "record",
+            "name": "CloudEvent",
+            "doc": "Avro Event Format for CloudEvents created with openedx_events/avro_attrs_bridge",
+            "fields": [
+                {"name": "test_data", "type":
+                    {"name": "TestData", "type": "record", "fields": [
+                        {"name": "sub_name", "type": "string"},
+                        {"name": "course_id", "type": "string"},
+                        {"name": "sub_test_0", "type": {
+                            "name": "SubTestData0",
+                            "type": "record",
+                            "fields": [
+                                {"name": "sub_name", "type": "string"},
+                                {"name": "course_id", "type": "string"},
+                            ]
+                        }},
+                        {"name": "sub_test_1", "type": {
+                            "name": "SubTestData1",
+                            "type": "record",
+                            "fields": [
+                                {"name": "sub_name", "type": "string"},
+                                {"name": "course_id", "type": "string"},
+                            ]
+                        }},
+                    ]}
+                 },
+            ],
+        }
+
+        self.assertDictEqual(bridge.schema_dict, expected_dict)
+
+    def test_multiple_top_level_fields(self):
+        SIGNAL = create_simple_signal({
+            "top_level_key_0": SubTestData0,
+            "top_level_key_1": SubTestData1,
+        })
+        bridge = AvroAttrsBridge(SIGNAL)
+
+        expected_dict = {
+            "type": "record",
+            "name": "CloudEvent",
+            "doc": "Avro Event Format for CloudEvents created with openedx_events/avro_attrs_bridge",
+            "fields": [
+                {"name": "top_level_key_0", "type":
+                    {
+                        "name": "SubTestData0",
+                        "type": "record",
+                        "fields": [
+                            {"name": "sub_name", "type": "string"},
+                            {"name": "course_id", "type": "string"},
+                        ]
+                    }
+                 },
+                {"name": "top_level_key_1", "type":
+                    {
+                        "name": "SubTestData1",
+                        "type": "record",
+                        "fields": [
+                            {"name": "sub_name", "type": "string"},
+                            {"name": "course_id", "type": "string"},
+                        ]
+                    }
+                 },
+            ],
+        }
+        self.assertDictEqual(bridge.schema_dict, expected_dict)
+
+    def test_convert_event_data_to_dict(self):
         """
-        Test to makes ure AvroattrsBridge works correctly with non-attr classes.
-
-        Specifically, testing to make sure the extension classes work as intended.
+        Tests that an event with complex attrs objects can be converted to dict and back
         """
-        bridge = AvroAttrsBridge(
-            CourseEnrollmentData,
-            extensions={
-                CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-            },
-        )
-        serialized_course_enrollment_data = bridge.serialize(
-            self.course_enrollment_data
-        )
 
-        object_from_wire = bridge.deserialize(serialized_course_enrollment_data)
-        assert self.course_enrollment_data == object_from_wire
-
-    def test_schema_evolution_add_value(self):
-        # Create object from old specification
-        old_bridge = AvroAttrsBridge(
-            CourseEnrollmentData,
-            extensions={
-                CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-            },
-        )
-        serialized_course_enrollment_data = old_bridge.serialize(
-            self.course_enrollment_data
+        SIGNAL = create_simple_signal({"test_data": TestData})
+        bridge = AvroAttrsBridge(SIGNAL)
+        # A test record that we can try to serialize to avro.
+        test_data = TestData(
+            "foo",
+            "bar.course",
+            SubTestData0("a.sub.name", "a.nother.course"),
+            SubTestData1("b.uber.sub.name", "b.uber.another.course"),
         )
 
-        def inner_scope(self):
-            @attr.s(frozen=True)
-            class CourseEnrollmentData:  # pylint: disable=redefined-outer-name
-                """
-                Temp class create to test schema evolution.
-                """
-
-                user = attr.ib(type=UserData)
-                course = attr.ib(type=CourseData)
-                mode = attr.ib(type=str)
-                is_active = attr.ib(type=bool)
-                creation_date = attr.ib(type=datetime)
-                is_active_2 = attr.ib(type=bool, default=False)
-                created_by = attr.ib(type=UserData, default=None)
-
-            new_bridge = AvroAttrsBridge(
-                CourseEnrollmentData,
-                extensions={
-                    CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
+        data_dict = bridge.to_dict({"test_data": test_data})
+        expected_dict = {
+            "test_data": {
+                "course_id": "bar.course",
+                "sub_name": "foo",
+                "sub_test_0": {"course_id": "a.nother.course", "sub_name": "a.sub.name"},
+                "sub_test_1": {
+                    "course_id": "b.uber.another.course",
+                    "sub_name": "b.uber.sub.name",
                 },
-            )
-            object_from_wire_as_dict = attr.asdict(
-                new_bridge.deserialize(
-                    serialized_course_enrollment_data, old_bridge.schema_dict
-                )
-            )
+            }
+        }
+        self.assertDictEqual(data_dict, expected_dict)
 
-            original_object_as_dict = attr.asdict(self.course_enrollment_data)
-            original_object_as_dict["is_active_2"] = False
-            assert object_from_wire_as_dict == original_object_as_dict
-
-        inner_scope(self)
-
-    def test_schema_evolution_remove_value(self):
-        # Create object from old specification
-        old_bridge = AvroAttrsBridge(
-            CourseEnrollmentData,
-            extensions={
-                CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-            },
-        )
-        serialized_course_enrollment_data = old_bridge.serialize(
-            self.course_enrollment_data
-        )
-
-        def inner_scope(self):
-            @attr.s(frozen=True)
-            class CourseEnrollmentData:  # pylint: disable=redefined-outer-name
-                """
-                Temp class create to test schema evolution.
-                """
-
-                user = attr.ib(type=UserData)
-                course = attr.ib(type=CourseData)
-                mode = attr.ib(type=str)
-                creation_date = attr.ib(type=datetime)
-                created_by = attr.ib(type=UserData, default=None)
-
-            new_bridge = AvroAttrsBridge(
-                CourseEnrollmentData,
-                extensions={
-                    CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
+    def test_convert_dict_to_event_data(self):
+        initial_dict = {
+            "test_data": {
+                "course_id": "bar.course",
+                "sub_name": "foo",
+                "sub_test_0": {"course_id": "a.nother.course", "sub_name": "a.sub.name"},
+                "sub_test_1": {
+                    "course_id": "b.uber.another.course",
+                    "sub_name": "b.uber.sub.name",
                 },
-            )
-            object_from_wire_as_dict = attr.asdict(
-                new_bridge.deserialize(
-                    serialized_course_enrollment_data, old_bridge.schema_dict
-                )
-            )
+            }
+        }
 
-            original_object_as_dict = attr.asdict(self.course_enrollment_data)
-            del original_object_as_dict["is_active"]
-            assert object_from_wire_as_dict == original_object_as_dict
+        SIGNAL = create_simple_signal({"test_data": TestData})
+        bridge = AvroAttrsBridge(SIGNAL)
+        event_data = bridge.from_dict(initial_dict)
 
-        inner_scope(self)
+        test_data = event_data["test_data"]
+        self.assertIsInstance(test_data, TestData)
+        self.assertEqual(test_data.course_id, "bar.course")
+        self.assertEqual(test_data.sub_name, "foo")
 
-    def test_schema_evolution_add_complex_value(self):
-        # Create object from old specification
-        old_bridge = AvroAttrsBridge(
-            CourseEnrollmentData,
-            extensions={
-                CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-            },
-        )
-        serialized_course_enrollment_data = old_bridge.serialize(
-            self.course_enrollment_data
-        )
+        sub_0 = test_data.sub_test_0
+        self.assertIsInstance(sub_0, SubTestData0)
+        self.assertEqual(sub_0.course_id, "a.nother.course")
+        self.assertEqual(sub_0.sub_name, "a.sub.name")
 
-        def inner_scope(self):
+        sub_1 = test_data.sub_test_1
+        self.assertIsInstance(sub_1, SubTestData1)
+        self.assertEqual(sub_1.course_id, "b.uber.another.course")
+        self.assertEqual(sub_1.sub_name, "b.uber.sub.name")
 
-            user_personal_data = UserPersonalData(
-                username="username", email="email", name="name"
-            )
-            user_data = UserData(id=1, is_active=True, pii=user_personal_data)
+    def test_full_serialize_and_deserialize(self):
+        SIGNAL = create_simple_signal({"test_data": TestData})
+        bridge = AvroAttrsBridge(SIGNAL)
+        test_data = {"test_data": TestData(
+            "foo",
+            "bar.course",
+            SubTestData0("a.sub.name", "a.nother.course"),
+            SubTestData1("b.uber.sub.name", "b.uber.another.course"),
+        )}
 
-            @attr.s(frozen=True)
-            class CourseEnrollmentData:  # pylint: disable=redefined-outer-name
-                """
-                Temp class create to test schema evolution.
-                """
+        as_bytes = serialize_event_data_to_bytes(bridge, test_data)
+        deserialized = deserialize_bytes_to_event_data(bridge, as_bytes)
+        self.assertEqual(test_data, deserialized)
+        # check we can emit the deserialized event with the original signal
+        SIGNAL.send_event(**deserialized)
 
-                user = attr.ib(type=UserData)
-                course = attr.ib(type=CourseData)
-                mode = attr.ib(type=str)
-                is_active = attr.ib(type=bool)
-                creation_date = attr.ib(type=datetime)
-                created_by = attr.ib(type=UserData, default=None)
-                user2 = attr.ib(type=UserData, default=user_data)
+    def test_default_datetime_extension_serialization(self):
+        SIGNAL = create_simple_signal({"birthday": datetime})
+        bridge = AvroAttrsBridge(SIGNAL)
+        birthday = datetime(year=1989, month=9, day=6)
+        test_data = {"birthday": birthday}
+        data_dict = bridge.to_dict(test_data)
+        assert data_dict == {"birthday": birthday.isoformat()}
 
-            new_bridge = AvroAttrsBridge(
-                CourseEnrollmentData,
-                extensions={
-                    CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-                },
-            )
-            object_from_wire_as_dict = attr.asdict(
-                new_bridge.deserialize(
-                    serialized_course_enrollment_data, old_bridge.schema_dict
-                )
-            )
+    def test_default_datetime_extension_deserialization(self):
+        SIGNAL = create_simple_signal({"birthday": datetime})
+        bridge = AvroAttrsBridge(SIGNAL)
+        birthday = datetime(year=1989, month=9, day=6)
+        as_dict = {"birthday": birthday.isoformat()}
+        event_data = bridge.from_dict(as_dict)
+        birthday_deserialized = event_data["birthday"]
+        self.assertIsInstance(birthday_deserialized, datetime)
+        self.assertEqual(birthday_deserialized.year, 1989)
+        self.assertEqual(birthday_deserialized.month, 9)
+        self.assertEqual(birthday_deserialized.day, 6)
 
-            original_object_as_dict = attr.asdict(self.course_enrollment_data)
-            original_object_as_dict["user2"] = attr.asdict(user_data)
-            assert object_from_wire_as_dict == original_object_as_dict
+    def test_default_coursekey_extension_serialization(self):
+        SIGNAL = create_simple_signal({"course": CourseKey})
+        bridge = AvroAttrsBridge(SIGNAL)
+        course_key = CourseKey.from_string("course-v1:edX+DemoX.1+2014")
+        test_data = {"course": course_key}
+        data_dict = bridge.to_dict(test_data)
+        assert data_dict == {"course": str(course_key)}
 
-        inner_scope(self)
+    def test_default_coursekey_extension_deserialization(self):
+        SIGNAL = create_simple_signal({"course": CourseKey})
+        bridge = AvroAttrsBridge(SIGNAL)
+        course_key = CourseKey.from_string("course-v1:edX+DemoX.1+2014")
+        as_dict = {"course": str(course_key)}
+        event_data = bridge.from_dict(as_dict)
+        course_deserialized = event_data["course"]
+        self.assertIsInstance(course_deserialized, CourseKey)
+        self.assertEqual(course_deserialized, course_key)
 
-    def test_schema_evolution_add_complex_extension_value(self):
-        # Create object from old specification
-        old_bridge = AvroAttrsBridge(
-            CourseEnrollmentData,
-            extensions={
-                CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-            },
-        )
-        serialized_course_enrollment_data = old_bridge.serialize(
-            self.course_enrollment_data
-        )
-
-        def inner_scope(self):
-
-            @attr.s(frozen=True)
-            class CourseEnrollmentData:  # pylint: disable=redefined-outer-name
-                """
-                Temp class create to test schema evolution.
-                """
-
-                user = attr.ib(type=UserData)
-                course = attr.ib(type=CourseData)
-                mode = attr.ib(type=str)
-                is_active = attr.ib(type=bool)
-                creation_date = attr.ib(type=datetime)
-                created_by = attr.ib(type=UserData, default=None)
-                added_date = attr.ib(type=datetime, default=None)
-
-            new_bridge = AvroAttrsBridge(
-                CourseEnrollmentData,
-                extensions={
-                    CourseKeyAvroAttrsBridgeExtension.cls: CourseKeyAvroAttrsBridgeExtension(),
-                },
-            )
-            object_from_wire_as_dict = attr.asdict(
-                new_bridge.deserialize(
-                    serialized_course_enrollment_data, old_bridge.schema_dict
-                )
-            )
-            original_object_as_dict = attr.asdict(self.course_enrollment_data)
-            original_object_as_dict["added_date"] = None
-            assert object_from_wire_as_dict == original_object_as_dict
-
-        inner_scope(self)
+    def test_custom_serializer(self):
+        SIGNAL = create_simple_signal({"test_data": NonAttrs})
+        bridge = AvroAttrsBridge(SIGNAL, extensions={SimpleBridgeExtension.cls: SimpleBridgeExtension()})
+        test_data = {
+            "test_data": NonAttrs("a.val", "a.nother.val")
+        }
+        as_bytes = serialize_event_data_to_bytes(bridge, test_data)
+        self.assertEqual(test_data, deserialize_bytes_to_event_data(bridge, as_bytes))
 
     def test_throw_exception_on_unextended_custom_type(self):
+        class UnextendedClass:
+            pass
+
+        SIGNAL = create_simple_signal({"unextended_class": UnextendedClass})
         with self.assertRaises(TypeError):
-            # CourseEnrollmentData has CourseKey and datetime as custom types
-            # This should raise TypeError cause no extensions are being passed to bridge
-            AvroAttrsBridge(CourseEnrollmentData)
+            AvroAttrsBridge(SIGNAL)
 
+    def test_dict_to_event_data_fails_if_missing_fields(self):
+        # missing "sub_name" field
+        initial_dict = {
+            "test_data": {
+                "course_id": "bar.course",
+            }
+        }
 
-def test_object_evolution_add_value():
-    @attr.s(auto_attribs=True)
-    class TestData:
-        sub_name: str
-        course_id: str
+        SIGNAL = create_simple_signal({"test_data": SubTestData0})
+        bridge = AvroAttrsBridge(SIGNAL)
+        with self.assertRaises(TypeError):
+            _ = bridge.from_dict(initial_dict)
 
-    original_bridge = AvroAttrsBridge(TestData)
+    def test_throw_exception_to_list_or_dict_types(self):
+        LIST_SIGNAL = create_simple_signal({"list_input": list})
+        DICT_SIGNAL = create_simple_signal({"list_input": dict})
+        with self.assertRaises(Exception):
+            AvroAttrsBridge(LIST_SIGNAL)
 
-    record = TestData("sub_name", "course_id")
-    serialized_record = original_bridge.serialize(record)
-
-    @attr.s(auto_attribs=True)
-    class TestData:  # pylint: disable=function-redefined
-        sub_name: str
-        course_id: str
-        added_key: str = "default_value"
-
-    new_bridge = AvroAttrsBridge(TestData)
-    deserialized_obj = new_bridge.deserialize(
-        serialized_record, original_bridge.schema_dict
-    )
-    assert deserialized_obj == TestData(
-        sub_name="sub_name", course_id="course_id", added_key="default_value"
-    )
-
-
-def test_object_evolution_remove_value():
-    @attr.s(auto_attribs=True)
-    class TestData:
-        sub_name: str
-        course_id: str
-        removed_key: str
-
-    original_bridge = AvroAttrsBridge(TestData)
-
-    record = TestData("sub_name", "course_id", "removed_value")
-    serialized_record = original_bridge.serialize(record)
-
-    @attr.s(auto_attribs=True)
-    class TestData:  # pylint: disable=function-redefined
-        sub_name: str
-        course_id: str
-
-    new_bridge = AvroAttrsBridge(TestData)
-    deserialized_obj = new_bridge.deserialize(
-        serialized_record, original_bridge.schema_dict
-    )
-    assert deserialized_obj == TestData(sub_name="sub_name", course_id="course_id")
-
-
-def test_base_types():
-    @attr.s(auto_attribs=True)
-    class SubTestData:
-        sub_name: str
-        course_id: str
-
-    @attr.s(auto_attribs=True)
-    class SubTestData2:
-        sub_name: str
-        course_id: str
-
-    @attr.s(auto_attribs=True)
-    class TestData:  # pylint: disable=missing-class-docstring
-        name: str
-        course_id: str
-        user_id: int
-        sub_test: SubTestData
-        uber_sub_test: SubTestData2
-
-    bridge = AvroAttrsBridge(TestData)
-
-    # A test record that we can try to serialize to avro.
-    record = TestData(
-        "foo",
-        "bar.course",
-        1,
-        SubTestData("a.sub.name", "a.nother.course"),
-        SubTestData2("b.uber.sub.name", "b.uber.another.course"),
-    )
-    serialized_record = bridge.serialize(record)
-
-    # Try to de-serialize back to an attrs class.
-    object_from_wire = bridge.deserialize(serialized_record)
-    assert record == object_from_wire
+        with self.assertRaises(Exception):
+            AvroAttrsBridge(DICT_SIGNAL)

--- a/openedx_events/bridge/tests/test_utilities.py
+++ b/openedx_events/bridge/tests/test_utilities.py
@@ -1,0 +1,123 @@
+"""
+Utility methods and classes for testing AvroAttrsBridge
+"""
+import io
+import re
+
+import attr
+import fastavro
+
+from openedx_events.bridge.avro_attrs_bridge_extensions import AvroAttrsBridgeExtention
+from openedx_events.tooling import OpenEdxPublicSignal
+
+
+def create_simple_signal(data_dict):
+    """
+    Create a basic OpenEdxPublicSignal with init_data = data_dict
+
+    Arguments:
+        data_dict: Description of attributes passed to the signal
+    """
+    return OpenEdxPublicSignal(
+        event_type="simple.signal",
+        data=data_dict
+    )
+
+
+def serialize_event_data_to_bytes(bridge, event_data):
+    """
+    Utility method to make sure an Avro serializer can actually serialize given a bridge schema and data
+    to serialize
+
+    Arguments:
+        bridge: An instance of AvroAttrsBridge
+        event_data: Event data to be sent via an OpenEdxPublicSignal's send_event method
+    Returns:
+        bytes: Byte representation of the event_data, to be sent over the wire
+    """
+    # Try to serialize using the generated schema.
+    out = io.BytesIO()
+    data_dict = bridge.to_dict(event_data)
+    fastavro.schemaless_writer(out, bridge.schema_dict, data_dict)
+    out.seek(0)
+    return out.read()
+
+
+def deserialize_bytes_to_event_data(bridge, bytes_from_wire):
+    """
+    Utility method to make sure an Avro deserializer can actually deserialize given a bridge and Avro-serialized
+    data
+
+    Arguments:
+        bridge: an instance of AvroAttrsBridge
+        bytes_from_wire: data that was serialized by an Avro serializer
+    """
+    data_file = io.BytesIO(bytes_from_wire)
+    as_dict = fastavro.schemaless_reader(data_file, bridge.schema_dict)
+    return bridge.from_dict(as_dict)
+
+
+# Useful simple attr classes
+@attr.s(auto_attribs=True)
+class SimpleAttrs:
+    """Class with all primitive type fields"""
+    boolean_field: bool
+    int_field: int
+    float_field: float
+    bytes_field: bytes
+    string_field: str
+
+
+@attr.s(auto_attribs=True)
+class SubTestData0:
+    """Subclass for testing nested attrs"""
+    sub_name: str
+    course_id: str
+
+
+@attr.s(auto_attribs=True)
+class SubTestData1:
+    """Subclass for testing nested attrs"""
+    sub_name: str
+    course_id: str
+
+
+@attr.s(auto_attribs=True)
+class TestData:
+    """More complex class for testing nested attrs"""
+    sub_name: str
+    course_id: str
+    sub_test_0: SubTestData0
+    sub_test_1: SubTestData1
+
+
+class NonAttrs:
+    """Data class not decorated with @attr. For testing bridge extension"""
+    def __init__(self, val0, val1):
+        self.val0 = val0
+        self.val1 = val1
+
+    def __eq__(self, other):
+        # Treat all instances with the same values as equal for easier testing
+        return self.val0 == other.val0 and self.val1 == other.val1
+
+
+class SimpleBridgeExtension(AvroAttrsBridgeExtention):
+    """
+    Simple Bridge Extension for de/serializing
+    """
+
+    cls = NonAttrs
+
+    def serialize(self, obj) -> str:
+        """Serialize obj into string."""
+        return f"{obj.val0}:{obj.val1}"
+
+    def deserialize(self, data: str):
+        """Deserialize string into obj."""
+        bits = re.split(":", data)
+        return NonAttrs(bits[0], bits[1])
+
+    def record_fields(self):
+        """Define Avro schema for self.cls."""
+        return "string"


### PR DESCRIPTION
**Description:** 
The original bridge converted ``attrs`` classes to Avro schemas. This PR updates the bridge class to take an instance of an OpenEdxPublicSignal and create an Avro schema representing its entire init_data (which defines the schema for events this signal expects to emit). This PR also removes any work around schema evolution, which will be left to future work. 
Finally, this PR updates the tests and documentation.

**JIRA:** 
[ARCHBOM-2038](https://openedx.atlassian.net/browse/ARCHBOM-2038)

**Testing instructions:**
See https://github.com/edx/edx-arch-experiments/blob/60730a6e78bd4ae6dcaf8c985a696f387b7efa29/edx_arch_experiments/kafka_consumer/tests/test_bridge_use.py for an example of how to test these events with the 
AvroDe/Serializer classes from the confluent_kafka packages.

**Reviewers:**
- [x] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
