### PR TITLE
docs: update docs including organization from eduNEXT/edx to openedx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,6 @@ Open edX Events
 
 Open edX Events from Hooks Extensions Framework (`OEP-50`_).
 
-What is this project?
 
 Overview
 --------
@@ -114,12 +113,12 @@ For more information about these options, see the `Getting Help`_ page.
     :target: https://pypi.python.org/pypi/openedx-events/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/eduNEXT/openedx-events/workflows/Python%20CI/badge.svg?branch=main
-    :target: https://github.com/eduNEXT/openedx-events/actions
+.. |ci-badge| image:: https://github.com/openedx/openedx-events/workflows/Python%20CI/badge.svg?branch=main
+    :target: https://github.com/openedx/openedx-events/actions
     :alt: CI
 
-.. |codecov-badge| image:: https://codecov.io/github/eduNEXT/openedx-events/coverage.svg?branch=main
-    :target: https://codecov.io/github/eduNEXT/openedx-events?branch=main
+.. |codecov-badge| image:: https://codecov.io/github/openedx/openedx-events/coverage.svg?branch=main
+    :target: https://codecov.io/github/openedx/openedx-events?branch=main
     :alt: Codecov
 
 .. |doc-badge| image:: https://readthedocs.org/projects/openedx-events/badge/?version=latest
@@ -130,6 +129,6 @@ For more information about these options, see the `Getting Help`_ page.
     :target: https://pypi.python.org/pypi/openedx-events/
     :alt: Supported Python versions
 
-.. |license-badge| image:: https://img.shields.io/github/license/eduNEXT/openedx-events.svg
-    :target: https://github.com/eduNEXT/openedx-events/blob/main/LICENSE.txt
+.. |license-badge| image:: https://img.shields.io/github/license/openedx/openedx-events.svg
+    :target: https://github.com/openedx/openedx-events/blob/main/LICENSE.txt
     :alt: License

--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,11 @@ with open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')) as changelog
 setup(
     name='openedx-events',
     version=VERSION,
-    description="""What is this project?""",
+    description="""Open edX Events from Hooks Extensions Framework (OEP-50).""",
     long_description=README + '\n\n' + CHANGELOG,
-    author='edX',
+    author='Open edX',
     author_email='oscm@edx.org',
-    url='https://github.com/edx/openedx-events',
+    url='https://github.com/openedx/openedx-events',
     packages=[
         'openedx_events',
     ],
@@ -83,7 +83,7 @@ setup(
     python_requires=">=3.8",
     license="AGPL 3.0",
     zip_safe=False,
-    keywords='Python edx',
+    keywords='Python openedx',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
**Description:** 
This PR updates documentation:
1. Changes occurrences of edx/edunext to Open edX/openedx
2. Add a short description
3. Change keywords