### PR TITLE
docs: fix eduNEXT to openedx move

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,12 +114,12 @@ For more information about these options, see the `Getting Help`_ page.
     :target: https://pypi.python.org/pypi/openedx-events/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/eduNEXT/openedx-events/workflows/Python%20CI/badge.svg?branch=main
-    :target: https://github.com/eduNEXT/openedx-events/actions
+.. |ci-badge| image:: https://github.com/openedx/openedx-events/workflows/Python%20CI/badge.svg?branch=main
+    :target: https://github.com/openedx/openedx-events/actions
     :alt: CI
 
-.. |codecov-badge| image:: https://codecov.io/github/eduNEXT/openedx-events/coverage.svg?branch=main
-    :target: https://codecov.io/github/eduNEXT/openedx-events?branch=main
+.. |codecov-badge| image:: https://codecov.io/github/openedx/openedx-events/coverage.svg?branch=main
+    :target: https://codecov.io/github/openedx/openedx-events?branch=main
     :alt: Codecov
 
 .. |doc-badge| image:: https://readthedocs.org/projects/openedx-events/badge/?version=latest
@@ -130,6 +130,6 @@ For more information about these options, see the `Getting Help`_ page.
     :target: https://pypi.python.org/pypi/openedx-events/
     :alt: Supported Python versions
 
-.. |license-badge| image:: https://img.shields.io/github/license/eduNEXT/openedx-events.svg
-    :target: https://github.com/eduNEXT/openedx-events/blob/main/LICENSE.txt
+.. |license-badge| image:: https://img.shields.io/github/license/openedx/openedx-events.svg
+    :target: https://github.com/openedx/openedx-events/blob/main/LICENSE.txt
     :alt: License

--- a/docs/decisions/0006-event-schema-serialization-and-evolution.rst
+++ b/docs/decisions/0006-event-schema-serialization-and-evolution.rst
@@ -31,7 +31,7 @@ Event bus technologies support various schema evolutions (`source <https://docs.
 
 - Full / Full Transitive: Allows you to add or delete optional fields. Either producer or consumer can change first.
 
-Currently, there are two notable classes related to schema: OpenEdxPublicSignal and attrs decorated classes in data.py modules (`example <https://github.com/eduNEXT/openedx-events/blob/main/openedx_events/learning/data.py>`_).
+Currently, there are two notable classes related to schema: OpenEdxPublicSignal and attrs decorated classes in data.py modules (`example <https://github.com/openedx/openedx-events/blob/main/openedx_events/learning/data.py>`_).
 
 OpenEdxPublicSignal defines all the information necessary to create, serialize, and send an event. This includes the data to be sent and the metadata. The data to be sent is defined as the 'init_data' attribute. 'init_data' is a dict of key/value pairs. The keys are strings and the values can be of various types (the exact supported types has not be specified yet). These keys correspond to keyword arguments sent via the signal.
 


### PR DESCRIPTION
**Description:**

Updates several url references from when this
repo was still part of the eduNEXT org, and not
yet part of the openedx org.
