### PR TITLE
build: Move where we set the DJANGO_SETTINGS_MODULE.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,9 @@ sys.path.append(REPO_ROOT)
 
 VERSION = get_version('../openedx_events', '__init__.py')
 
+# Set the DJANGO_SETTINGS_MODULE if it's not set.
+if not os.environ.get('DJANGO_SETTINGS_MODULE'):
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'test_utils.test_settings'
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ commands =
 
 [testenv:docs]
 setenv =
-    DJANGO_SETTINGS_MODULE = test_utils.test_settings
     PYTHONPATH = {toxinidir}
 whitelist_externals =
     make


### PR DESCRIPTION
It was previously being set in the tox.ini which was fine when we were building
locally but readthedocs.org does not use it.  Moving the setting into
docs/conf.py means it should work from anywhere.
