### PR TITLE
build: Fail docs builds on sphinx warnings.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
   version: 3.8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,7 +212,7 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/openedx_events/utils.py
+++ b/openedx_events/utils.py
@@ -40,14 +40,18 @@ def format_responses(obj, indent=1, width=80, depth=None, *, compact=False, sort
     """
     Format a Django Signal response object into a pretty-printed representation.
 
-    Example usage:
+    Example usage::
 
         log.info(
                 "Responses of the Open edX Event <%s>: %s",
                 self.event_type,
                 format_responses(responses, depth=2),
-            )
-        Will result in:
+        )
+
+    Will result in:
+
+    .. code-block:: none
+
         [
             (
                 'openedx_basic_hooks.receivers.login_receiver',

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ commands =
 [testenv:docs]
 setenv =
     PYTHONPATH = {toxinidir}
+    SPHINXOPTS = -W
 whitelist_externals =
     make
     rm
@@ -54,8 +55,9 @@ commands =
     doc8 --ignore-path docs/_build README.rst docs
     rm -f docs/openedx_events.rst
     rm -f docs/modules.rst
-    make -C docs clean
-    make -C docs html
+    # -e allows for overriding setting from the environment so that SPHINXOPTS gets picked up.
+    make -e -C docs clean
+    make -e -C docs html
     python setup.py check --restructuredtext --strict
 
 [testenv:quality]


### PR DESCRIPTION
**Description:** Fail doc builds on warnings.

**Testing instructions:**

1. Run `make docs`
2. Verify that no warnings are displayed and docs build successfully.

**Reviewers:**
- [ ] @robrap
- [ ] @mariajgrimaldi

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
