### PR TITLE
feat: update DiscussionTopicContext to add additional context [BD-38] [TNL-9673]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+[0.8.2] - 2022-04-13
+--------------------
+Changed
+~~~~~~~
+* Changed openedx_events.learning.data.DiscussionTopicContext to make the group id optional
+* Changed DiscussionTopicContext to add a `context` attribute
+
 [0.8.1] - 2022-03-03
 --------------------
 
@@ -94,7 +101,7 @@ Added
 Changed
 ~~~~~~~
 
-* Update reposirtory purpose.
+* Update repository purpose.
 * Changed max-doc-length from 79 to 120 following community recommendation.
 
 [0.1.3] - 2021-07-01

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -5,7 +5,7 @@ These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import attr
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -149,17 +149,20 @@ class DiscussionTopicContext:
         title (str): title of the discussion. This field is cached to improve the performance, since otherwise we'd
         need to look it up in the course structure each time.
         usage_key (str): unit location.
-        group_id (int): can be used for providers that don't internally support
+        group_id (Optional[int]): can be used for providers that don't internally support
         cohorting but we can emulate that with different contexts for different groups.
         external_id (str): store the commentable id that is used by cs_comments_service.
         ordering (int): represent the position of the discussion topic.
+        context (dict): additional structured information about the context in
+          which this topic is used, such as the section, subsection etc.
     """
 
     title = attr.ib(type=str)
     usage_key = attr.ib(type=UsageKey, default=None)
-    group_id = attr.ib(type=int, default=None)
+    group_id = attr.ib(type=Optional[int], default=None)
     external_id = attr.ib(type=str, default=None)
     ordering = attr.ib(type=int, default=None)
+    context = attr.ib(type=dict, factory=dict)
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
**Description:** 
Adds a new `context` field to DiscussionTopicContext that can be used to store
additional context information such as the topics's section and subsection.

This ADR with additional information on this can be found here:
https://github.com/openedx/edx-platform/pull/29928

It also marks the `group_id` attr as optional.

**JIRA:** https://openedx.atlassian.net/browse/TNL-9673

**Installation instructions:** 
- In the lms and cms containers install this PR using: 
  `pip install git+https://github.com/openedx/openedx-events.git@refs/pull/51/head`

**Testing instructions:**

Follow instructions from: https://github.com/openedx/edx-platform/pull/30140


**Reviewers:**
- [ ] @tecoholic

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)