### PR TITLE
build: Add structured Maintainers information

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'openedx-events'
+  description: "This repository implements the necessary tooling and definitions used by the Hooks Extension Framework to manage the events execution and extra tools."
+  links:
+    - url: "http://github.com/openedx/openedx-events"
+      title: "Source Code"
+      icon: "Code"
+  annotations:
+    openedx.org/arch-interest-groups: "mariajgrimaldi,felipemontoya"
+spec:
+  owner: group:hooks-extension-framework
+  type: 'source-code'
+  lifecycle: 'production'


### PR DESCRIPTION
**Description:** This adds the catalog-info.yml file, which provides structured data around Maintainers for a new tool we're using called Backstage

**Merge deadline:** Needs to go along with the OEP-55 (maintainers)  work that I believe @mariajgrimaldi is going to work on.

**Reviewers:**
- [ ] @mariajgrimaldi 
- [ ] @feanil  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None
