### PR TITLE
docs: change readme structure following maintainers OEP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,23 @@ Getting started
 Dependencies
 ~~~~~~~~~~~~
 
+Dependencies of the current version of the library:
+
+- attrs
+- Django
+- edx-opaque-keys
+- fastavro
+
 Installation
 ~~~~~~~~~~~~
 
-Configuration
-~~~~~~~~~~~~~
+.. code-block:: bash
+
+    # Install from PyPi
+    pip install openedx-events==<RELEASE>
+
+    # Install from GitHub Repository
+    pip install git+https://github.com/openedx/openedx-events.git@<TAG or BRANCH>
 
 Development Workflow
 ~~~~~~~~~~~~~~~~~~~~
@@ -80,9 +92,6 @@ Documentation
 
 See `documentation on Read the Docs <https://openedx-events.readthedocs.io/en/latest/>`_.
 
-
-
-
 License
 -------
 
@@ -95,7 +104,7 @@ How To Contribute
 -----------------
 
 Contributions are very welcome.
-Please read `How To Contribute <https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
+Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
 Even though they were written with ``edx-platform`` in mind, the guidelines
 should be followed for all Open edX projects.
 
@@ -119,10 +128,23 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help`_ page.
 
+Additional Resources
+--------------------
+
+- For a detailed description of the project, refer to the `OEP-50`_.
+- For usage samples, please refer to `openedx-events-2-zapier`_.
+- For general guidance, refer to the `Hooks Extension Framework guide`.
+- For implementation details, refer to the `BD-32 pull requests`_ on the Open edX platform and this library.
+- For architectural design details, refer the current `ADRs`_.
+
 .. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 .. _OEP-50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html
+.. _openedx-events-2-zapier: https://github.com/eduNEXT/openedx-events-2-zapier
+.. _ Hooks Extension Framework: https://github.com/openedx/edx-platform/tree/master/docs/guides/hooks
+.. _ BD-32 pull requests: https://github.com/openedx/edx-platform/pulls?q=is%3Apr+%22BD-32%22
+.. _ ADRs: https://github.com/openedx/openedx-events/tree/main/docs/decisions
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/openedx-events.svg
     :target: https://pypi.python.org/pypi/openedx-events/

--- a/README.rst
+++ b/README.rst
@@ -6,25 +6,27 @@ Open edX Events
 
 Open edX Events from Hooks Extensions Framework (`OEP-50`_).
 
-What is this project?
-
 Overview
 --------
 
 This repository implements the necessary tooling and definitions used by the
 Hooks Extension Framework to manage the events execution and extra tools.
 
-Documentation
--------------
+Getting started
+---------------
 
-See `documentation on Read the Docs <https://openedx-events.readthedocs.io/en/latest/>`_.
+Dependencies
+~~~~~~~~~~~~
+
+Installation
+~~~~~~~~~~~~
+
+Configuration
+~~~~~~~~~~~~~
 
 Development Workflow
---------------------
-
-One Time Setup
-~~~~~~~~~~~~~~
-.. code-block::
+~~~~~~~~~~~~~~~~~~~~
+.. code-block:: bash
 
   # Clone the repository
   git clone git@github.com:openedx/openedx-events.git
@@ -32,11 +34,6 @@ One Time Setup
 
   # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
   mkvirtualenv -p python3.8 openedx-events
-
-
-Every time you develop something in this repo
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. code-block::
 
   # Activate the virtualenv
   workon openedx-events
@@ -57,17 +54,34 @@ Every time you develop something in this repo
   # Using your favorite editor, edit the code to make your change.
   vim …
 
+  # Commit all your changes
+  git commit …
+  git push
+
+  # Open a PR and ask for review.
+
+Running the tests
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
   # Run your new tests
   pytest ./path/to/new/tests
 
   # Run all the tests and quality checks
   make validate
 
-  # Commit all your changes
-  git commit …
-  git push
 
-  # Open a PR and ask for review.
+Getting help
+------------
+
+Documentation
+~~~~~~~~~~~~~
+
+See `documentation on Read the Docs <https://openedx-events.readthedocs.io/en/latest/>`_.
+
+
+
 
 License
 -------

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ with open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')) as changelog
 setup(
     name='openedx-events',
     version=VERSION,
-    description="""What is this project?""",
+    description="""Open edX events from the Hooks Extensions Framework.""",
     long_description=README + '\n\n' + CHANGELOG,
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
**Description:** 
This PR updates the current readme documentation following the suggestions in the [OEP-55](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html#id23).

**Reviewers:**
- [ ] TBD

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
