### PR TITLE
fix: remove email from subscription license event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Unreleased
 Changed
 ~~~~~~~
 
+[0.9.1] - 2022-05-20
+--------------------
+Changed
+~~~~~~~
+* Remove assigned_email from SubscriptionLicenseData
+
 [0.9.0] - 2022-04-28
 --------------------
 Changed

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -7,6 +7,7 @@ pattern.
 import attr
 
 
+# TODO (EventBus): consider how to proactively prevent PII from being sent to kafka
 @attr.s(frozen=True)
 class SubscriptionLicenseData:
     """
@@ -27,8 +28,6 @@ class SubscriptionLicenseData:
                                May be empty.
         assigned_lms_user_id (str): The LMS User id of the user that this license 'belongs to'.
                                     May be empty if this license is not activated yet.
-        assigned_email (str): The email assigned to this license.
-                              Will be empty if this license is not assigned to a learner yet.
         expiration_processed (bool): Boolean value of License 'expiration_processed' field, may be True or False.
                                      True means a license is expired.
         auto_applied (bool):
@@ -44,7 +43,6 @@ class SubscriptionLicenseData:
     previous_license_uuid = attr.ib(type=str)
     assigned_date = attr.ib(type=str)
     activation_date = attr.ib(type=str)
-    assigned_email = attr.ib(type=str)
     expiration_processed = attr.ib(type=bool)
     assigned_lms_user_id = attr.ib(type=int, default=None)
     auto_applied = attr.ib(type=bool, default=False)

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -23,7 +23,7 @@ from openedx_events.tooling import OpenEdxPublicSignal
 #           See: https://openedx.atlassian.net/browse/ARCHBOM-2008 for more details.
 # .. event_data: SubscriptionLicenseData
 SUBSCRIPTION_LICENSE_MODIFIED = OpenEdxPublicSignal(
-    event_type="org.openedx.enterprise.subscription.license.modified.v1",
+    event_type="org.openedx.enterprise.subscription.license.modified.v0",
     data={
         "license": SubscriptionLicenseData,
     }


### PR DESCRIPTION
**Description:** Removes email from SubscriptionLicenseData attrs object to prevent it from going to Kafka

Also changes the Subscription License Modified event to v0 to make it clear it should not be used in production and might be modified at any time.

In a future world this type of thing would require more thoughts around migration but that will wait until after we have something end-to-end with the bridge.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.