### PR TITLE
docs: Fix org name in getting-started instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ One Time Setup
 .. code-block::
 
   # Clone the repository
-  git clone git@github.com:edxuNEXT/openedx-events.git
+  git clone git@github.com:openedx/openedx-events.git
   cd openedx-events
 
   # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it


### PR DESCRIPTION
Looks like this was missed in the earlier search/replace due to the typo.

**Merge checklist:**
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
