### PR TITLE
fix: Update the slack invite link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help`_ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 .. _OEP-50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html


### PR DESCRIPTION
Point to the openedx.org shortcut which we can update as needed.