### PR TITLE
test: Add unit test locking in KeyError when signal not found

### DIFF
--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -1,4 +1,5 @@
-"""This file contains all test for the tooling.py file.
+"""
+This file contains all test for the tooling.py file.
 
 Classes:
     EventsToolingTest: Test events tooling.
@@ -7,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import attr
 import ddt
+import pytest
 from django.test import TestCase, override_settings
 
 from openedx_events.exceptions import SenderValidationError
@@ -43,6 +45,18 @@ class OpenEdxPublicSignalTestCache(FreezeSignalCacheMixin, TestCase):
             The representation contains the event_type.
         """
         self.assertIn(self.event_type, str(self.public_signal))
+
+    def test_get_signal_by_type(self):
+        """
+        Test found and not-found behavior.
+        """
+        assert isinstance(
+            OpenEdxPublicSignal.get_signal_by_type('org.openedx.learning.session.login.completed.v1'),
+            OpenEdxPublicSignal
+        )
+
+        with pytest.raises(KeyError):
+            OpenEdxPublicSignal.get_signal_by_type('xxx')
 
     @override_settings(SERVICE_VARIANT="lms")
     @patch("openedx_events.data.openedx_events")

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -57,6 +57,8 @@ class OpenEdxPublicSignal(Signal):
     def get_signal_by_type(cls, event_type):
         """
         Get event identified by type.
+
+        Raises KeyError if not found.
         """
         return cls._mapping[event_type]
 


### PR DESCRIPTION
I wanted to start relying on the KeyError not-found behavior in another library and realized it wasn't actually documented or tested.