### PR TITLE
fix: Handle optional (None) values for custom serializers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Unreleased
 Changed
 ~~~~~~~
 
+[0.11.1] - 2022-07-28
+---------------------
+Fixed
+~~~~~
+* Handle optional (None) values for custom serializers
+
 [0.11.0] - 2022-07-21
 ---------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/openedx_events/event_bus/avro/tests/test_utilities.py
+++ b/openedx_events/event_bus/avro/tests/test_utilities.py
@@ -3,9 +3,11 @@ Utility methods and classes for testing various modules in event_bus.avro.
 """
 import io
 import re
+from datetime import datetime
 
 import attr
 import fastavro
+from opaque_keys.edx.keys import CourseKey
 
 from openedx_events.event_bus.avro.custom_serializers import BaseCustomTypeAvroSerializer
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer
@@ -106,6 +108,20 @@ class SimpleAttrsWithDefaults:
     bytes_field = attr.ib(type=bytes, default=None)
     string_field = attr.ib(type=str, default=None)
     attrs_field = attr.ib(type=SimpleAttrs, default=None)
+
+
+@attr.s(frozen=True)
+class CustomAttrsWithDefaults:
+    """Test attrs with nullable values"""
+    coursekey_field = attr.ib(type=CourseKey, default=None)
+    datetime_field = attr.ib(type=datetime, default=None)
+
+
+@attr.s(frozen=True)
+class CustomAttrsWithoutDefaults:
+    """Test attrs without nullable values"""
+    coursekey_field = attr.ib(type=CourseKey)
+    datetime_field = attr.ib(type=datetime)
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Fixes https://github.com/openedx/openedx-events/issues/82

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed