### PR TITLE
feat!: Removed `org` and `number` fields from `CourseCatalogData`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,13 @@ Change Log
 
 Unreleased
 ----------
+
+[0.12.0] - 2022-08-16
+---------------------
 Changed
 ~~~~~~~
+* **Breaking change**: Removed ``org`` and ``number`` fields from ``CourseCatalogData``
+  (should only affect unreleased event-bus code, though)
 
 [0.11.1] - 2022-07-28
 ---------------------

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -41,8 +41,6 @@ class CourseCatalogData:
     Arguments:
         course_key (CourseKey): identifier of the Course object.
         name (str): course name
-        org (str): course organization identifier
-        number (str): course number
         schedule_data (CourseScheduleData): scheduling information for the course
         short_description (str): one- or two-sentence course description (optional)
         effort (str): estimated level of effort in hours per week (optional). Kept as a str to align with the lms model.
@@ -53,8 +51,6 @@ class CourseCatalogData:
     # basic identifiers
     course_key = attr.ib(type=CourseKey)
     name = attr.ib(type=str)
-    number = attr.ib(type=str)
-    org = attr.ib(type=str)
 
     # additional marketing information
     schedule_data = attr.ib(type=CourseScheduleData)


### PR DESCRIPTION
These are redundant with course key and can be added back in later if we
actually need them.

This is a breaking change but it should only affect event-bus code that
hasn't yet been merged.

See discussion here:
https://github.com/openedx/openedx-events/issues/72#issuecomment-1212177933

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
