### PR TITLE
docs: update readme following oep-55 recommendations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,29 +1,27 @@
 Open edX Events
-===============
+###############
 
 |pypi-badge| |ci-badge| |codecov-badge| |doc-badge| |pyversions-badge|
-|license-badge|
+|license-badge| |status-badge|
 
 Open edX Events from Hooks Extensions Framework (`OEP-50`_).
 
-What is this project?
+.. _OEP-50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html
 
-Overview
---------
+Purpose
+*******
 
 This repository implements the necessary tooling and definitions used by the
 Hooks Extension Framework to manage the events execution and extra tools.
 
-Documentation
--------------
+Getting Started
+***************
 
-See `documentation on Read the Docs <https://openedx-events.readthedocs.io/en/latest/>`_.
-
-Development Workflow
---------------------
+Developing
+==========
 
 One Time Setup
-~~~~~~~~~~~~~~
+--------------
 .. code-block::
 
   # Clone the repository
@@ -33,16 +31,15 @@ One Time Setup
   # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
   mkvirtualenv -p python3.8 openedx-events
 
-
 Every time you develop something in this repo
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------
 .. code-block::
 
   # Activate the virtualenv
   workon openedx-events
 
   # Grab the latest code
-  git checkout master
+  git checkout main
   git pull
 
   # Install/update the dev requirements
@@ -69,46 +66,82 @@ Every time you develop something in this repo
 
   # Open a PR and ask for review.
 
-License
--------
+Deploying
+=========
 
-The code in this repository is licensed under the AGPL 3.0 unless
-otherwise noted.
+The Open edX Events component is a Python library which doesn't need independent deployment. Therefore,
+its setup is reasonably straightforward. First, it needs to be added to your service requirements,
+and then it will be installed alongside requirements of the service.
 
-Please see `LICENSE.txt <LICENSE.txt>`_ for details.
-
-How To Contribute
------------------
-
-Contributions are very welcome.
-Please read `How To Contribute <https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
-Even though they were written with ``edx-platform`` in mind, the guidelines
-should be followed for all Open edX projects.
-
-The pull request description template should be automatically applied if you are creating a pull request from GitHub. Otherwise you
-can find it at `PULL_REQUEST_TEMPLATE.md <.github/PULL_REQUEST_TEMPLATE.md>`_.
-
-The issue report template should be automatically applied if you are creating an issue on GitHub as well. Otherwise you
-can find it at `ISSUE_TEMPLATE.md <.github/ISSUE_TEMPLATE.md>`_.
-
-Reporting Security Issues
--------------------------
-
-Please do not report security issues in public. Please email security@edx.org.
+If the service you intend to use is either the LMS or CMS, then the library is installed alongside
+their requirements since the Maple release.
 
 Getting Help
-------------
+************
 
-If you're having trouble, we have discussion forums at https://discuss.openedx.org where you can connect with others in the community.
+Documentation
+=============
 
-Our real-time conversations are on Slack. You can request a `Slack invitation`_, then join our `community Slack workspace`_.
+See `documentation on Read the Docs <https://openedx-events.readthedocs.io/en/latest/>`_.
+
+More Help
+=========
+
+If you're having trouble, we have discussion forums at
+https://discuss.openedx.org where you can connect with others in the
+community.
+
+Our real-time conversations are on Slack. You can request a `Slack
+invitation`_, then join our `community Slack workspace`_.
+
+For anything non-trivial, the best path is to open an issue in this
+repository with as many details about the issue you are facing as you
+can provide.
+
+https://github.com/openedx/openedx-events/issues
 
 For more information about these options, see the `Getting Help`_ page.
 
 .. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
-.. _OEP-50: https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html
+
+License
+*******
+
+The code in this repository is licensed under the AGPL 3.0 unless
+otherwise noted.
+
+Please see `LICENSE.txt <LICENSE.txt>`_ for details.
+
+Contributing
+************
+
+Contributions are very welcome.
+Please read `How To Contribute <https://openedx.org/r/how-to-contribute>`_ for details.
+
+This project is currently accepting all types of contributions, bug fixes,
+security fixes, maintenance work, or new features.  However, please make sure
+to have a discussion about your new feature idea with the maintainers prior to
+beginning development to maximize the chances of your change being accepted.
+You can start a conversation by creating a new issue on this repo summarizing
+your idea.
+
+The Open edX Code of Conduct
+****************************
+
+All community members are expected to follow the `Open edX Code of Conduct`_.
+
+.. _Open edX Code of Conduct: https://openedx.org/code-of-conduct/
+
+People
+******
+
+The assigned maintainers for this component and other project details may be
+found in `Backstage`_. Backstage pulls this data from the ``catalog-info.yaml``
+file in this repo.
+
+.. _Backstage: https://backstage.openedx.org/catalog/default/component/openedx-events
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/openedx-events.svg
     :target: https://pypi.python.org/pypi/openedx-events/
@@ -133,3 +166,5 @@ For more information about these options, see the `Getting Help`_ page.
 .. |license-badge| image:: https://img.shields.io/github/license/openedx/openedx-events.svg
     :target: https://github.com/openedx/openedx-events/blob/main/LICENSE.txt
     :alt: License
+
+.. |status-badge| image:: https://img.shields.io/badge/Status-Maintained-brightgreen


### PR DESCRIPTION
**Description:** 
This PR updates the readme file following the OEP-55 recommendations, especially [this](https://raw.githubusercontent.com/openedx/edx-cookiecutters/master/python-template/%7B%7Bcookiecutter.placeholder_repo_name%7D%7D/README.rst) cookie-cutter template. 

This PR resolves #92. 

**Dependencies:**
None

**Merge deadline:**
ASAP

**Installation instructions:** 
Just documentation.

**Testing instructions:**
Just documentation.

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
~~**Question**: in the deployment section, should we add that the library works out of the box since maple?~~ already resolved
