### PR TITLE
build: change GitHub to community maintained repository health file

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -1,55 +1,26 @@
-name: Upgrade Requirements
+name: Upgrade Python Requirements
 
 on:
   schedule:
-    # will start the job at 01:15 UTC every Tuesday
-    - cron: "15 1 * * 3"
+    # will start the job at 13:00 UTC every Friday
+    - cron: "0 13 * * 5"
   workflow_dispatch:
     inputs:
       branch:
-        description: "Target branch to create requirements PR against"
+        description: "Target branch against which to create requirements PR"
         required: true
-        default: 'main'
+        default: "main"
 
 jobs:
-  upgrade_requirements:
-    runs-on: ubuntu-22.04
-
-    strategy:
-      matrix:
-        python-version: ["3.8"]
-
-    steps:
-      - name: setup target branch
-        run: echo "target_branch=$(if ['${{ github.event.inputs.branch }}' = '']; then echo 'main'; else echo '${{ github.event.inputs.branch }}'; fi)" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v1
-        with:
-          ref: ${{ env.target_branch }}
-
-      - name: setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: make upgrade
-        run: |
-          cd $GITHUB_WORKSPACE
-          make upgrade
-
-      - name: setup testeng-ci
-        run: |
-          git clone https://github.com/edx/testeng-ci.git
-          cd $GITHUB_WORKSPACE/testeng-ci
-          pip install -r requirements/base.txt
-      - name: create pull request
-        env:
-          GITHUB_TOKEN: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
-          GITHUB_USER_EMAIL: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
-        run: |
-          cd $GITHUB_WORKSPACE/testeng-ci
-          python -m jenkins.pull_request_creator --repo-root=$GITHUB_WORKSPACE \
-          --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
-          --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
-          --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-          --user-reviewers="" --team-reviewers="hooks-extension-framework" --delete-old-pull-requests
+  call-upgrade-python-requirements-workflow:
+    uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
+    with:
+      branch: ${{ github.event.inputs.branch || '"main"' }}
+      # optional parameters below; fill in if you'd like github or email notifications
+      # user_reviewers: ""
+      team_reviewers: "hooks-extension-framework"
+      # email_address: ""
+      # send_success_notification: false
+    secrets:
+      requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
+      requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+* Improvements in make upgrade command and requirements files.
+* Manually update requirements files to fix requirements bot issue with pip/setup tools.
+* Change GitHub workflow to community maintained repository health file.
+
 [0.12.0] - 2022-08-16
 ---------------------
 Changed


### PR DESCRIPTION
**Description:**
This PR changes the current requirements bot for a community-supported health file. We're also changing this job in an attempt to fix the current bot errors: https://github.com/openedx/openedx-events/actions/workflows/upgrade-python-requirements.yml

**Dependencies:**
None

**Merge deadline:**
ASAP

**Installation instructions:** 
None

**Testing instructions:**
None

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)