### PR TITLE
fix: add missing secrets for requirements job

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -24,3 +24,5 @@ jobs:
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
       requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
+      edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
+      edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}


### PR DESCRIPTION
**Description:**
This PR adds missing SMTP secrets for the requirements job, which [failed](https://github.com/openedx/openedx-events/actions/runs/3024132560) while setting up the environment. This is a continuation of PR #106 since we missed those secrets there.

**JIRA:** 
None

**Dependencies:** 
None

**Merge deadline:** 
ASAP

**Installation instructions:** 
None, it's a github action change.

**Testing instructions:**
1. Go to actions
2. Select this branch
3. Select upgrade requirements job
4. Run job
You'll pass the setup step, & it will fail while creating the pull request.

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
The job fails with 404 while creating the pull request, more info [here](https://github.com/openedx/openedx-events/runs/8275216199?check_suite_focus=true#step:7:54)
