### PR TITLE
ci: add coverage step as part of CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,10 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
         run: tox
+
+      - name: Run coverage
+        if: matrix.python-version == '3.8' && matrix.toxenv == 'py38'
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          fail_ci_if_error: true


### PR DESCRIPTION
**Description:**
This PR adds coverage step to CI GitHub pipeline.

**Dependencies:**
None

**Merge deadline:** 
ASAP

**Installation instructions:** 
None. New GitHub pipeline step.

**Testing instructions:**
None. New GitHub pipeline step. Check out the org coverage page for openedx-events: [here](https://app.codecov.io/gh/openedx/openedx-events/pull/111)

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
None
