### PR TITLE
docs: ADR for course-catalog-info-changed event design

### DIFF
--- a/docs/decisions/0009-course-catalog-info-changed-design.rst
+++ b/docs/decisions/0009-course-catalog-info-changed-design.rst
@@ -1,0 +1,37 @@
+8. Event design of the COURSE_CATALOG_INFO_CHANGED signal
+=========================================================
+
+Status
+------
+
+Provisional
+
+Context
+-------
+
+The COURSE_CATALOG_INFO_CHANGED signal is used by Studio to convey that information relevant to the course catalog has changed. It was created with an eye towards eventually replacing the refresh-course-metadata batch job, which syncs all data between edx-platform and course-discovery.
+
+Refresh-course-metadata functions differently depending on whether or not the system has Publisher enabled. Specifically, after requesting information from the /courses endpoint in Studio, Discovery will ignore certain fields if Publisher is enabled. These fields are mostly part of the `media` attribute of the API response. They are sent in a variety of ways (absolute urls, paths, sometimes divided by size, etc.)
+
+
+Decision
+--------
+
+The COURSE_CATALOG_INFO_CHANGED will only contain the information necessary to work in a Publisher-enabled environment. In particular, this means it will not contain the `media` field usually present in the Studio /courses API endpoint.
+
+In Discovery, if Publisher is not enabled, the consumer will simply ignore the event and not try to update anything.
+
+Rationale
+---------
+
+The way we update media information in refresh-course-metadata is quite haphazard, with no real standard way of sending over the information or of storing it on the Discovery end. Replicating these structures in the COURSE_CATALOG_INFO_CHANGED signal would make the data definition confusing. Moreover, edx.org has Publisher enabled and would thus ignore these fields anyway.
+
+Deferred work
+-------------
+It is possible in the future we will want to use this event to sync data between Studio and Discovery in systems that do not include Publisher. At that time, we can work on cleaning up the media data structures for cleaner event definitions.
+
+Github discussion
+-----------------
+For discussion on the initial event design, see https://github.com/openedx/openedx-events/issues/72 .
+For discussion on the removal of the media fields, see the comments on this PR: https://github.com/openedx/openedx-events/pull/81 .
+

--- a/docs/decisions/0009-course-catalog-info-changed-design.rst
+++ b/docs/decisions/0009-course-catalog-info-changed-design.rst
@@ -18,7 +18,7 @@ Decision
 
 The COURSE_CATALOG_INFO_CHANGED will only contain the information necessary to work in a Publisher-enabled environment. In particular, this means it will not contain the ``media`` field usually present in the Studio ``/courses`` API endpoint.
 
-In Discovery, if Publisher is not enabled, the consumer will simply ignore the event and not try to update anything.
+In Discovery, if Publisher is not enabled, the consumer will log a warning and not try to update anything.
 
 Rationale
 ---------

--- a/docs/decisions/0009-course-catalog-info-changed-design.rst
+++ b/docs/decisions/0009-course-catalog-info-changed-design.rst
@@ -11,13 +11,12 @@ Context
 
 The COURSE_CATALOG_INFO_CHANGED signal is used by Studio to convey that information relevant to the course catalog has changed. It was created with an eye towards eventually replacing the refresh-course-metadata batch job, which syncs all data between edx-platform and course-discovery.
 
-Refresh-course-metadata functions differently depending on whether or not the system has Publisher enabled. Specifically, after requesting information from the /courses endpoint in Studio, Discovery will ignore certain fields if Publisher is enabled. These fields are mostly part of the `media` attribute of the API response. They are sent in a variety of ways (absolute urls, paths, sometimes divided by size, etc.)
-
+Refresh-course-metadata functions differently depending on whether or not the system has Publisher enabled. Specifically, after requesting information from the ``/courses`` endpoint in Studio, Discovery will ignore certain fields if Publisher is enabled. These fields are mostly part of the ``media`` attribute of the API response. They are sent in a variety of ways (absolute urls, paths, sometimes divided by size, etc.)
 
 Decision
 --------
 
-The COURSE_CATALOG_INFO_CHANGED will only contain the information necessary to work in a Publisher-enabled environment. In particular, this means it will not contain the `media` field usually present in the Studio /courses API endpoint.
+The COURSE_CATALOG_INFO_CHANGED will only contain the information necessary to work in a Publisher-enabled environment. In particular, this means it will not contain the ``media`` field usually present in the Studio ``/courses`` API endpoint.
 
 In Discovery, if Publisher is not enabled, the consumer will simply ignore the event and not try to update anything.
 

--- a/docs/decisions/0009-course-catalog-info-changed-design.rst
+++ b/docs/decisions/0009-course-catalog-info-changed-design.rst
@@ -23,7 +23,9 @@ In Discovery, if Publisher is not enabled, the consumer will log a warning and n
 Rationale
 ---------
 
-The way we update media information in refresh-course-metadata is quite haphazard, with no real standard way of sending over the information or of storing it on the Discovery end. Replicating these structures in the COURSE_CATALOG_INFO_CHANGED signal would make the data definition confusing. Moreover, edx.org has Publisher enabled and would thus ignore these fields anyway.
+The way we update media information in refresh-course-metadata is quite haphazard, with no real standard way of sending over the information or of storing it on the Discovery end. Replicating these structures in the COURSE_CATALOG_INFO_CHANGED signal would make the data definition confusing.
+
+Until these fields are needed by a consumer in a non-Publisher environment (if ever), it makes sense to defer trying to find a good solution to this problem.
 
 Deferred work
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Contents:
    decisions/0006-event-schema-serialization-and-evolution
    decisions/0007-optional-fields
    decisions/0008-signals-with-pii
+   decisions/0009-course-catalog-info-changed-design
 
 
 Indices and tables


### PR DESCRIPTION
**Description:** Adds an ADR explaining the rationale for designing the course-catalog-info-changed event in such a way as to only work when Publisher is enabled.

Since it's just a docs update I didn't update the version


**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

