### PR TITLE
build: expand '$default-branch' in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: '$default-branch'
+        default: 'main'
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || '$default-branch' }}
+      branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       team_reviewers: "hooks-extension-framework"


### PR DESCRIPTION
We added `$default-branch` to the upgrade workflow
based on the upgrade workflow's template in
our .github repo.

It turns out that `$default-branch` only works in
workflow templates. In actual workflows,
it needs to be expanded to `main` or `master`.

@mariajgrimaldi @sarina 