### PR TITLE
Bump version: 0.12.0 → 0.13.0

### DIFF
--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.2
+current_version = 0.13.0
 commit = True
 tag = True
 


### PR DESCRIPTION
**Description:** 
This PR bumps the library version references to v0.13.0
