### PR TITLE
feat: remove unused short_description field on CourseCatalogData

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 ----------
+
+[0.14.0] - 2022-09-21
+---------------------
+Changed
+~~~~~~~
+* **Breaking change**: Removed ``short_description`` from ``CourseCatalogData``
+
 [0.13.0] - 2022-09-16
 ---------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -42,7 +42,6 @@ class CourseCatalogData:
         course_key (CourseKey): identifier of the Course object.
         name (str): course name
         schedule_data (CourseScheduleData): scheduling information for the course
-        short_description (str): one- or two-sentence course description (optional)
         effort (str): estimated level of effort in hours per week (optional). Kept as a str to align with the lms model.
         hidden (bool): whether the course is hidden from search (optional)
         invitation_only (bool): whether the course requires an invitation to enroll
@@ -54,7 +53,6 @@ class CourseCatalogData:
 
     # additional marketing information
     schedule_data = attr.ib(type=CourseScheduleData)
-    short_description = attr.ib(type=str, default=None)
     effort = attr.ib(type=str, default=None)
     hidden = attr.ib(type=bool, default=False)
     invitation_only = attr.ib(type=bool, default=False)


### PR DESCRIPTION
**Description:** Removes the short_description field from CourseCatalogData since it's not used in systems that have publisher. See 0009-course-catalog-info-changed-design.rst . 

**ISSUE:** https://github.com/openedx/openedx-events/issues/121



**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.