### PR TITLE
docs: Bump version to 1.x to acknowledge that this is in use in production

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,11 @@ Change Log
 
 Unreleased
 ----------
+
+[1.0.0] - 2022-09-27
+--------------------
 * **Breaking Change**: Updated from ``Django 2.0`` to ``Django 3.0``.
+* Bump version to 1.x to acknowledge that this is in use in production
 
 [0.14.0] - 2022-09-21
 ---------------------

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "0.14.0"
+__version__ = "1.0.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 1.0.0
 commit = True
 tag = True
 


### PR DESCRIPTION
According to semver, 0.x versions may have breaking changes at any time, and there's no way to communicate them via the version number until the version is at least 1.0.0. Since this is in active use now, we should bump to 1.0.0.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
