### PR TITLE
fix: use None instead of null as default value for optional fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[3.0.1] - 2022-10-31
+--------------------
+Fixed
+~~~~~
+* Fix default value for optional fields from "null" to None
+
 [3.0.0] - 2022-10-19
 --------------------
 * **Breaking change**: Removed (optional) field ``effort`` from ``CourseCatalogData.`` Nothing should be relying on this field as it is not used by Course Discovery in Publisher-enabled setups.

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/openedx_events/event_bus/avro/schema.py
+++ b/openedx_events/event_bus/avro/schema.py
@@ -90,7 +90,7 @@ def _create_avro_field_definition(data_key, data_type, previously_seen_types,
             " defined in custom_type_to_avro_type."
         )
     if default_is_none:
-        field["default"] = "null"
+        field["default"] = None
         single_type = field["type"]
         field["type"] = ["null", single_type]
     return field

--- a/openedx_events/event_bus/avro/tests/test_schema.py
+++ b/openedx_events/event_bus/avro/tests/test_schema.py
@@ -162,12 +162,12 @@ class TestSchemaGeneration(TestCase):
             "fields": [
                 {"name": "test_data", "type":
                     {"name": "SimpleAttrsWithDefaults", "type": "record", "fields": [
-                        {"name": "boolean_field", "type": ["null", "boolean"], "default": "null"},
-                        {"name": "int_field", "type": ["null", "long"], "default": "null"},
-                        {"name": "float_field", "type": ["null", "double"], "default": "null"},
-                        {"name": "bytes_field", "type": ["null", "bytes"], "default": "null"},
-                        {"name": "string_field", "type": ["null", "string"], "default": "null"},
-                        {"name": "attrs_field", "default": "null",
+                        {"name": "boolean_field", "type": ["null", "boolean"], "default": None},
+                        {"name": "int_field", "type": ["null", "long"], "default": None},
+                        {"name": "float_field", "type": ["null", "double"], "default": None},
+                        {"name": "bytes_field", "type": ["null", "bytes"], "default": None},
+                        {"name": "string_field", "type": ["null", "string"], "default": None},
+                        {"name": "attrs_field", "default": None,
                          "type": ["null",
                                   {"name": "SimpleAttrs", "type": "record", "fields": [
                                       {"name": "boolean_field", "type": "boolean"},
@@ -201,12 +201,12 @@ class TestSchemaGeneration(TestCase):
                             'name': 'SimpleAttrsWithDefaults',
                             'type': 'record',
                             'fields': [
-                                {'name': 'boolean_field', 'type': ['null', 'boolean'], 'default': 'null'},
-                                {'name': 'int_field', 'type': ['null', 'long'], 'default': 'null'},
-                                {'name': 'float_field', 'type': ['null', 'double'], 'default': 'null'},
-                                {'name': 'bytes_field', 'type': ['null', 'bytes'], 'default': 'null'},
-                                {'name': 'string_field', 'type': ['null', 'string'], 'default': 'null'},
-                                {'name': 'attrs_field', 'default': 'null',
+                                {'name': 'boolean_field', 'type': ['null', 'boolean'], 'default': None},
+                                {'name': 'int_field', 'type': ['null', 'long'], 'default': None},
+                                {'name': 'float_field', 'type': ['null', 'double'], 'default': None},
+                                {'name': 'bytes_field', 'type': ['null', 'bytes'], 'default': None},
+                                {'name': 'string_field', 'type': ['null', 'string'], 'default': None},
+                                {'name': 'attrs_field', 'default': None,
                                  'type': ['null', {
                                      'name': 'SimpleAttrs',
                                      'type': 'record',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ django==3.2.16
     #   -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via -r requirements/base.in
-fastavro==1.6.1
+fastavro==1.7.0
     # via -r requirements/base.in
 pbr==5.10.0
     # via stevedore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -97,7 +97,7 @@ edx-lint==5.3.0
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==2.3.0
     # via -r requirements/quality.txt
-fastavro==1.6.1
+fastavro==1.7.0
     # via -r requirements/quality.txt
 filelock==3.8.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -56,7 +56,7 @@ edx-opaque-keys[django]==2.3.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-fastavro==1.6.1
+fastavro==1.7.0
     # via -r requirements/test.txt
 idna==3.4
     # via requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -58,7 +58,7 @@ edx-lint==5.3.0
     # via -r requirements/quality.in
 edx-opaque-keys[django]==2.3.0
     # via -r requirements/test.txt
-fastavro==1.6.1
+fastavro==1.7.0
     # via -r requirements/test.txt
 idna==3.4
     # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,7 @@ django==3.2.16
     #   -r requirements/base.txt
 edx-opaque-keys[django]==2.3.0
     # via -r requirements/base.txt
-fastavro==1.6.1
+fastavro==1.7.0
     # via -r requirements/base.txt
 iniconfig==1.1.1
     # via pytest


### PR DESCRIPTION
**Description:** 
Use None instead of null as the default value for optional fields to fix the fastavro error "Default value <null> must match first schema in union with type: null"

See https://github.com/openedx/openedx-events/pull/137


**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.