### PR TITLE
fix: contrain fastavro

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,3 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 -c common_constraints.txt
+
+# Keep fastavro constrained to ensure that unit tests pass before dependent services
+#  try to update fastavro. Upgrade at any time by adjusting to the latest version,
+#  ensuring tests continue to pass, and publishing a patch release.
+fastavro==1.6.1


### PR DESCRIPTION
**Description:** 

Add constraint for fastavro, forcing manual
upgrades to ensure it passes tests before
being upgraded in dependent services.

**ISSUE:**

Here was a PR related to a fastavro change that broken unit tests: https://github.com/openedx/openedx-events/pull/137. However, because we weren't constraining, services had upgraded the breaking change. This would be most dangerous if it started breaking event production.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped (**this is still needed!**)
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

My concern is that this means this constraint would need to be manually changed any time we wanted to upgrade. Who would watch for this and ensure we are getting security updates, or not getting too far behind, etc.?