### PR TITLE
feat: adds events to handle changes in xblocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[4.1.0] - 2023-01-03
+---------------------
+Added
+~~~~~~~
+* Added new XBLOCK_PUBLISHED, XBLOCK_DUPLICATED and XBLOCK_DELETED signals in content_authoring.
+* Added XBlockData and DuplicatedXBlockData classes
+* Added custom UsageKeyAvroSerializer for opaque_keys UsageKey.
+
 [4.0.0] - 2022-12-01
 --------------------
 Changed

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -10,7 +10,7 @@ The attributes for the events come from the CourseDetailView in the LMS, with so
 from datetime import datetime
 
 import attr
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 
 @attr.s(frozen=True)
@@ -54,3 +54,31 @@ class CourseCatalogData:
     schedule_data = attr.ib(type=CourseScheduleData)
     hidden = attr.ib(type=bool, default=False)
     invitation_only = attr.ib(type=bool, default=False)
+
+
+@attr.s(frozen=True)
+class XBlockData:
+    """
+    Data about changed XBlock.
+
+    Arguments:
+        usage_key (UsageKey): identifier of the XBlock object.
+        block_type (str): type of block.
+    """
+
+    usage_key = attr.ib(type=UsageKey)
+    block_type = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
+class DuplicatedXBlockData(XBlockData):
+    """
+    Data about duplicated XBlock.
+
+    This class extends XBlockData to include source_usage_key.
+
+    Arguments:
+        source_usage_key (UsageKey): identifier of the source XBlock object.
+    """
+
+    source_usage_key = attr.ib(type=UsageKey)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -8,7 +8,7 @@ They also must comply with the payload definition specified in
 docs/decisions/0003-events-payload.rst
 """
 
-from openedx_events.content_authoring.data import CourseCatalogData
+from openedx_events.content_authoring.data import CourseCatalogData, DuplicatedXBlockData, XBlockData
 from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.content_authoring.course.catalog_info.changed.v1
@@ -19,5 +19,46 @@ COURSE_CATALOG_INFO_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.course.catalog_info.changed.v1",
     data={
         "catalog_info": CourseCatalogData,
+    }
+)
+
+
+# .. event_type: org.openedx.content_authoring.xblock.published.v1
+# .. event_name: XBLOCK_PUBLISHED
+# .. event_description: Fired when an XBlock is published. If a parent block
+#       with changes in one or more child blocks is published, only a single
+#       XBLOCK_PUBLISHED event is fired with parent block details.
+#       For example: If a section is published with changes in multiple units,
+#       only a single event is fired with section details like :
+#       `XBlockData(usage_key="section-usage-key", block_type="chapter")`
+# .. event_data: XBlockData
+XBLOCK_PUBLISHED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.published.v1",
+    data={
+        "xblock_info": XBlockData,
+    }
+)
+
+
+# .. event_type: org.openedx.content_authoring.xblock.deleted.v1
+# .. event_name: XBLOCK_DELETED
+# .. event_description: Fired when an XBlock is deleted.
+# .. event_data: XBlockData
+XBLOCK_DELETED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.deleted.v1",
+    data={
+        "xblock_info": XBlockData,
+    }
+)
+
+
+# .. event_type: org.openedx.content_authoring.xblock.duplicated.v1
+# .. event_name: XBLOCK_DUPLICATED
+# .. event_description: Fired when an XBlock is duplicated in Studio.
+# .. event_data: DuplicatedXBlockData
+XBLOCK_DUPLICATED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.duplicated.v1",
+    data={
+        "xblock_info": DuplicatedXBlockData,
     }
 )

--- a/openedx_events/event_bus/avro/custom_serializers.py
+++ b/openedx_events/event_bus/avro/custom_serializers.py
@@ -5,7 +5,7 @@ Classes to serialize and deserialize custom types used by openedx events. See RE
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx_events.event_bus.avro.types import PYTHON_TYPE_TO_AVRO_MAPPING
 
@@ -71,4 +71,23 @@ class DatetimeAvroSerializer(BaseCustomTypeAvroSerializer):
         return datetime.fromisoformat(data)
 
 
-DEFAULT_CUSTOM_SERIALIZERS = [CourseKeyAvroSerializer, DatetimeAvroSerializer]
+class UsageKeyAvroSerializer(BaseCustomTypeAvroSerializer):
+    """
+    CustomTypeAvroSerializer for UsageKey class.
+    """
+
+    cls = UsageKey
+    field_type = PYTHON_TYPE_TO_AVRO_MAPPING[str]
+
+    @staticmethod
+    def serialize(obj) -> str:
+        """Serialize obj into string."""
+        return str(obj)
+
+    @staticmethod
+    def deserialize(data: str):
+        """Deserialize string into obj."""
+        return UsageKey.from_string(data)
+
+
+DEFAULT_CUSTOM_SERIALIZERS = [CourseKeyAvroSerializer, DatetimeAvroSerializer, UsageKeyAvroSerializer]

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from unittest import TestCase
 
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 # Each new folder with signals must be manually imported in order for the signals to be cached
 #   and used in the unit tests. Using 'disable=reimported' with pylint will work,
@@ -49,6 +49,9 @@ def generate_test_event_data_for_data_type(data_type):
         str: "default",
         float: 1.0,
         CourseKey: CourseKey.from_string("course-v1:edX+DemoX.1+2014"),
+        UsageKey: UsageKey.from_string(
+            "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
+        ),
         datetime: datetime.now(),
     }
     for attribute in data_type.__attrs_attrs__:

--- a/openedx_events/event_bus/avro/tests/test_deserializer.py
+++ b/openedx_events/event_bus/avro/tests/test_deserializer.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from unittest import TestCase
 
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer
 from openedx_events.event_bus.avro.tests.test_utilities import (
@@ -101,6 +101,21 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         course_deserialized = event_data["course"]
         self.assertIsInstance(course_deserialized, CourseKey)
         self.assertEqual(course_deserialized, course_key)
+
+    def test_default_usagekey_deserialization(self):
+        """
+        Test deserialization of UsageKey
+        """
+        SIGNAL = create_simple_signal({"usage_key": UsageKey})
+        deserializer = AvroSignalDeserializer(SIGNAL)
+        usage_key = UsageKey.from_string(
+            "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
+        )
+        as_dict = {"usage_key": str(usage_key)}
+        event_data = deserializer.from_dict(as_dict)
+        usage_key_deserialized = event_data["usage_key"]
+        self.assertIsInstance(usage_key_deserialized, UsageKey)
+        self.assertEqual(usage_key_deserialized, usage_key)
 
     def test_deserialization_with_custom_serializer(self):
         SIGNAL = create_simple_signal({"test_data": NonAttrs})

--- a/openedx_events/event_bus/avro/tests/test_serializer.py
+++ b/openedx_events/event_bus/avro/tests/test_serializer.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import pytest
 from django.test import TestCase
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
 from openedx_events.event_bus.avro.tests.test_utilities import (
@@ -104,6 +104,19 @@ class TestAvroSignalSerializerCache(FreezeSignalCacheMixin, TestCase):
         test_data = {"course": course_key}
         data_dict = serializer.to_dict(test_data)
         self.assertDictEqual(data_dict, {"course": str(course_key)})
+
+    def test_default_usagekey_serialization(self):
+        """
+        Test serialization of UsageKey
+        """
+        SIGNAL = create_simple_signal({"usage_key": UsageKey})
+        serializer = AvroSignalSerializer(SIGNAL)
+        usage_key = UsageKey.from_string(
+            "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
+        )
+        test_data = {"usage_key": usage_key}
+        data_dict = serializer.to_dict(test_data)
+        self.assertDictEqual(data_dict, {"usage_key": str(usage_key)})
 
     def test_serialization_with_custom_serializer(self):
         SIGNAL = create_simple_signal({"test_data": NonAttrs})


### PR DESCRIPTION
**Description:** Adds events and data classes to allow consumers to react on xblock events like published, deleted and duplicated. 
The idea is to fire these events in [delete_item](https://github.com/openedx/edx-platform/blob/4c0b0f99a0d874c589c4dbf1ea44cdfc84edf7f9/lms/djangoapps/ccx/modulestore.py#L237), [publish_item](https://github.com/openedx/edx-platform/blob/4c0b0f99a0d874c589c4dbf1ea44cdfc84edf7f9/lms/djangoapps/ccx/modulestore.py#L263) and [_duplicate_item](https://github.com/openedx/edx-platform/blob/5bc00b373c879fb2859b44d338f81647210c0909/cms/djangoapps/contentstore/views/item.py#L878) and update skills related to the xblock in [taxonomy-connector](https://github.com/openedx/taxonomy-connector) (part of course-discovery).

**Answer for a question asked in previous similar MRs:**

_Do consumers have to make separate requests to get more information?_
**Generally:** Additional data if required related to the event needs to be fetch separately as it can be different for different use case.
**Specifically for skill tagging:** Yes, for skill tagging to work we need concatenated text representation of children xblocks for units and transcript for video xblocks which can be extracted using [index_dictionary](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/edx_search.html#which-data-gets-indexed) of the xblock. The idea is to add a new api to fetch block metadata and use this API in taxonomy-connector.

**Related MRs**:
These MRs are the foundation for storing skills related on xblocks level, specifically for unit and video xblocks.
- https://github.com/openedx/taxonomy-connector/pull/119
- https://github.com/open-craft/taxonomy-connector/pull/1
- https://github.com/openedx/edx-platform/pull/31273

**ISSUE:** Link to GitHub issue

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
