### PR TITLE
feat!: make event_metadata parameter required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[4.0.0] - 2022-12-01
+--------------------
+Changed
+~~~~~~~
+* **Breaking change** Make event_metadata parameter in EventBusProducer send API required
+
 [3.2.0] - 2022-11-30
 --------------------
 Changed

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -94,7 +94,7 @@ class NoEventBusProducer(EventBusProducer):
 
     def send(
             self, *, signal: OpenEdxPublicSignal, topic: str, event_key_field: str, event_data: dict,
-            event_metadata: EventsMetadata = None,
+            event_metadata: EventsMetadata,
     ) -> None:
         """Do nothing."""
 

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -72,7 +72,7 @@ class EventBusProducer(ABC):
     @abstractmethod
     def send(
             self, *, signal: OpenEdxPublicSignal, topic: str, event_key_field: str, event_data: dict,
-            event_metadata: EventsMetadata = None
+            event_metadata: EventsMetadata
     ) -> None:
         """
         Send a signal event to the event bus under the specified topic.
@@ -83,7 +83,7 @@ class EventBusProducer(ABC):
             event_key_field: Path to the event data field to use as the event key (period-delimited
               string naming the dictionary keys to descend)
             event_data: The event data (kwargs) sent to the signal
-            event_metadata: (optional) The CloudEvent metadata
+            event_metadata: The CloudEvent metadata
         """
 
 

--- a/openedx_events/event_bus/tests/test_loader.py
+++ b/openedx_events/event_bus/tests/test_loader.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 
 from django.test import override_settings
 
+from openedx_events.data import EventsMetadata
 from openedx_events.event_bus import _try_load, get_producer
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 
@@ -108,5 +109,5 @@ class TestProducer(TestCase):
             # Nothing thrown, no warnings.
             assert producer.send(
                 signal=SESSION_LOGIN_COMPLETED, topic='user-logins',
-                event_key_field='user.id', event_data={},
+                event_key_field='user.id', event_data={}, event_metadata=EventsMetadata(event_type='eh', minorversion=0)
             ) is None


### PR DESCRIPTION
**Description:**
Make the event_metadata parameter in the send() method of the EventProducer class required. 

**ISSUE:** https://github.com/openedx/openedx-events/issues/153

**Dependencies:** Don't merge until after https://github.com/openedx/event-bus-kafka/pull/88 is merged
**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.