### PR TITLE
feat: xblock skill verification event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[5.1.0] - 2023-02-07
+---------------------
+Added
+~~~~~~~
+* Added support for array type.
+* Added new XBLOCK_SKILL_VERIFIED event.
+* Added XBlockSkillVerificationData classes.
+
 [5.0.0] - 2023-02-03
 --------------------
 Changed
@@ -44,14 +52,6 @@ Changed
 Changed
 ~~~~~~~
 * Use collections.abc import to use with python 3.8 and 3.10.
-
-[4.2.0] - 2023-01-04
----------------------
-Added
-~~~~~~~
-* Added support for array type.
-* Added new XBLOCK_SKILL_VERIFIED event.
-* Added XBlockSkillVerificationData classes.
 
 [4.1.0] - 2023-01-03
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,14 @@ Changed
 ~~~~~~~
 * Use collections.abc import to use with python 3.8 and 3.10.
 
+[4.2.0] - 2023-01-04
+---------------------
+Added
+~~~~~~~
+* Added support for array type.
+* Added new XBLOCK_SKILL_VERIFIED event.
+* Added XBlockSkillVerificationData classes.
+
 [4.1.0] - 2023-01-03
 ---------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"

--- a/openedx_events/event_bus/avro/deserializer.py
+++ b/openedx_events/event_bus/avro/deserializer.py
@@ -38,7 +38,7 @@ def _deserialized_avro_record_dict_to_object(data: dict, data_type, deserializer
         return deserializer(data)
     elif data_type in PYTHON_TYPE_TO_AVRO_MAPPING:
         return data
-    elif PYTHON_TYPE_TO_AVRO_MAPPING.get(data_type_origin) == "array":
+    elif data_type_origin == list:
         # returns types of list contents
         # if data_type == List[int], arg_data_type = (int,)
         arg_data_type = get_args(data_type)

--- a/openedx_events/event_bus/avro/schema.py
+++ b/openedx_events/event_bus/avro/schema.py
@@ -8,7 +8,7 @@ TODO: Handle optional parameters and allow for schema evolution. https://github.
 from typing import get_args, get_origin
 
 from .custom_serializers import DEFAULT_CUSTOM_SERIALIZERS
-from .types import PYTHON_TYPE_TO_AVRO_MAPPING
+from .types import PYTHON_TYPE_TO_AVRO_MAPPING, SIMPLE_PYTHON_TYPE_TO_AVRO_MAPPING
 
 DEFAULT_FIELD_TYPES = {serializer.cls: serializer.field_type for serializer in DEFAULT_CUSTOM_SERIALIZERS}
 
@@ -71,7 +71,12 @@ def _create_avro_field_definition(data_key, data_type, previously_seen_types,
             raise TypeError(
                 "List without annotation type is not supported. The argument should be a type, for eg., List[int]"
             )
-        avro_type = PYTHON_TYPE_TO_AVRO_MAPPING[arg_data_type[0]]
+        avro_type = SIMPLE_PYTHON_TYPE_TO_AVRO_MAPPING.get(arg_data_type[0])
+        if avro_type is None:
+            raise TypeError(
+                "Only following types are supported for list arguments:"
+                f" {set(SIMPLE_PYTHON_TYPE_TO_AVRO_MAPPING.keys())}"
+            )
         field["type"] = {"type": PYTHON_TYPE_TO_AVRO_MAPPING[data_type_origin], "items": avro_type}
     # Case 3: data_type is an attrs class
     elif hasattr(data_type, "__attrs_attrs__"):

--- a/openedx_events/event_bus/avro/schema.py
+++ b/openedx_events/event_bus/avro/schema.py
@@ -53,6 +53,8 @@ def _create_avro_field_definition(data_key, data_type, previously_seen_types,
     """
     field = {"name": data_key}
     all_field_type_overrides = custom_type_to_avro_type or {}
+    # get generic type of data_type
+    # if data_type == List[int], data_type_origin = list
     data_type_origin = get_origin(data_type)
 
     # Case 1: data_type has a predetermined avro field representation
@@ -65,7 +67,9 @@ def _create_avro_field_definition(data_key, data_type, previously_seen_types,
             raise Exception("Unable to generate Avro schema for dict or array fields without annotation types.")
         avro_type = PYTHON_TYPE_TO_AVRO_MAPPING[data_type]
         field["type"] = avro_type
-    elif PYTHON_TYPE_TO_AVRO_MAPPING.get(data_type_origin) == "array":
+    elif data_type_origin == list:
+        # returns types of list contents
+        # if data_type == List[int], arg_data_type = (int,)
         arg_data_type = get_args(data_type)
         if not arg_data_type:
             raise TypeError(

--- a/openedx_events/event_bus/avro/serializer.py
+++ b/openedx_events/event_bus/avro/serializer.py
@@ -43,7 +43,8 @@ def _get_non_attrs_serializer(serializers=None):
 
         for extended_class, serializer in all_serializers.items():
             if field:
-                if issubclass(field.type, extended_class):
+                # Make sure that field.type is a class first.
+                if isinstance(field.type, type) and issubclass(field.type, extended_class):
                     return serializer(value)
             if issubclass(type(value), extended_class):
                 return serializer(value)

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -1,5 +1,6 @@
 """Test interplay of the various Avro helper classes"""
 from datetime import datetime
+from typing import List
 from unittest import TestCase
 
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -51,6 +52,7 @@ def generate_test_event_data_for_data_type(data_type):
         UsageKey: UsageKey.from_string(
             "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
         ),
+        List[int]: [1, 2, 3],
         datetime: datetime.now(),
     }
     for attribute in data_type.__attrs_attrs__:

--- a/openedx_events/event_bus/avro/tests/test_deserializer.py
+++ b/openedx_events/event_bus/avro/tests/test_deserializer.py
@@ -194,6 +194,7 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         """
         Check that deserialization raises error when list data is not annotated.
         """
+        # create dummy signal to test deserializer
         SIGNAL = create_simple_signal({"list_input": List[int]})
         LIST_SIGNAL = create_simple_signal({"list_input": List})
         initial_dict = {"list_input": [1, 3]}
@@ -206,10 +207,23 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         """
         Check that deserialization raises error when nested list data is passed.
         """
+        # create dummy signal to test deserializer
         SIGNAL = create_simple_signal({"list_input": List[int]})
         LIST_SIGNAL = create_simple_signal({"list_input": List[List[int]]})
         initial_dict = {"list_input": [[1, 3], [4, 5]]}
         deserializer = AvroSignalDeserializer(SIGNAL)
         deserializer.signal = LIST_SIGNAL
+        with self.assertRaises(TypeError):
+            deserializer.from_dict(initial_dict)
+
+    def test_deserialization_of_nested_list_with_complex_types_fails(self):
+        SIGNAL = create_simple_signal({"list_input": List[list]})
+        with self.assertRaises(TypeError):
+            AvroSignalDeserializer(SIGNAL)
+        initial_dict = {"list_input": [[1, 3], [4, 5]]}
+        # create dummy signal to test deserializer
+        DUMMY_SIGNAL = create_simple_signal({"list_input": List[int]})
+        deserializer = AvroSignalDeserializer(DUMMY_SIGNAL)
+        deserializer.signal = SIGNAL
         with self.assertRaises(TypeError):
             deserializer.from_dict(initial_dict)

--- a/openedx_events/event_bus/avro/tests/test_deserializer.py
+++ b/openedx_events/event_bus/avro/tests/test_deserializer.py
@@ -1,6 +1,7 @@
 """Tests for avro.deserializer"""
 import json
 from datetime import datetime
+from typing import List
 from unittest import TestCase
 
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -175,3 +176,40 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         nested_field = data_dict["data"].field_0
         self.assertIsInstance(nested_field, SimpleAttrsWithDefaults)
         self.assertEqual(nested_field, SimpleAttrsWithDefaults())
+
+    def test_deserialization_of_list_with_annotation(self):
+        """
+        Check that deserialization works as expected when list data is annotated.
+        """
+        LIST_SIGNAL = create_simple_signal({"list_input": List[int]})
+        initial_dict = {"list_input": [1, 3]}
+        deserializer = AvroSignalDeserializer(LIST_SIGNAL)
+        event_data = deserializer.from_dict(initial_dict)
+        expected_event_data = [1, 3]
+        test_data = event_data["list_input"]
+        self.assertIsInstance(test_data, list)
+        self.assertEqual(test_data, expected_event_data)
+
+    def test_deserialization_of_list_without_annotation(self):
+        """
+        Check that deserialization raises error when list data is not annotated.
+        """
+        SIGNAL = create_simple_signal({"list_input": List[int]})
+        LIST_SIGNAL = create_simple_signal({"list_input": List})
+        initial_dict = {"list_input": [1, 3]}
+        deserializer = AvroSignalDeserializer(SIGNAL)
+        deserializer.signal = LIST_SIGNAL
+        with self.assertRaises(TypeError):
+            deserializer.from_dict(initial_dict)
+
+    def test_deserialization_of_nested_list_fails(self):
+        """
+        Check that deserialization raises error when nested list data is passed.
+        """
+        SIGNAL = create_simple_signal({"list_input": List[int]})
+        LIST_SIGNAL = create_simple_signal({"list_input": List[List[int]]})
+        initial_dict = {"list_input": [[1, 3], [4, 5]]}
+        deserializer = AvroSignalDeserializer(SIGNAL)
+        deserializer.signal = LIST_SIGNAL
+        with self.assertRaises(TypeError):
+            deserializer.from_dict(initial_dict)

--- a/openedx_events/event_bus/avro/tests/test_deserializer.py
+++ b/openedx_events/event_bus/avro/tests/test_deserializer.py
@@ -194,11 +194,13 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         """
         Check that deserialization raises error when list data is not annotated.
         """
-        # create dummy signal to test deserializer
+        # create dummy signal to bypass schema check while initializing deserializer
+        # This allows us to test whether correct exceptions are raised while deserializing data
         SIGNAL = create_simple_signal({"list_input": List[int]})
         LIST_SIGNAL = create_simple_signal({"list_input": List})
         initial_dict = {"list_input": [1, 3]}
         deserializer = AvroSignalDeserializer(SIGNAL)
+        # Update signal with incomplete type info
         deserializer.signal = LIST_SIGNAL
         with self.assertRaises(TypeError):
             deserializer.from_dict(initial_dict)
@@ -207,11 +209,13 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         """
         Check that deserialization raises error when nested list data is passed.
         """
-        # create dummy signal to test deserializer
+        # create dummy signal to bypass schema check while initializing deserializer
+        # This allows us to test whether correct exceptions are raised while deserializing data
         SIGNAL = create_simple_signal({"list_input": List[int]})
         LIST_SIGNAL = create_simple_signal({"list_input": List[List[int]]})
         initial_dict = {"list_input": [[1, 3], [4, 5]]}
         deserializer = AvroSignalDeserializer(SIGNAL)
+        # Update signal with incomplete type info
         deserializer.signal = LIST_SIGNAL
         with self.assertRaises(TypeError):
             deserializer.from_dict(initial_dict)
@@ -221,9 +225,11 @@ class TestAvroSignalDeserializerCache(TestCase, FreezeSignalCacheMixin):
         with self.assertRaises(TypeError):
             AvroSignalDeserializer(SIGNAL)
         initial_dict = {"list_input": [[1, 3], [4, 5]]}
-        # create dummy signal to test deserializer
+        # create dummy signal to bypass schema check while initializing deserializer
+        # This allows us to test whether correct exceptions are raised while deserializing data
         DUMMY_SIGNAL = create_simple_signal({"list_input": List[int]})
         deserializer = AvroSignalDeserializer(DUMMY_SIGNAL)
+        # Update signal with incorrect type info
         deserializer.signal = SIGNAL
         with self.assertRaises(TypeError):
             deserializer.from_dict(initial_dict)

--- a/openedx_events/event_bus/avro/tests/test_schema.py
+++ b/openedx_events/event_bus/avro/tests/test_schema.py
@@ -1,7 +1,7 @@
 """
 Tests for event_bus.avro.schema module
 """
-from typing import Dict, List
+from typing import List
 from unittest import TestCase
 
 from openedx_events.event_bus.avro.schema import schema_from_signal
@@ -236,22 +236,13 @@ class TestSchemaGeneration(TestCase):
         with self.assertRaises(TypeError):
             schema_from_signal(SIGNAL)
 
-    def test_throw_exception_to_list_or_dict_types(self):
+    def test_throw_exception_to_list_or_dict_types_without_annotation(self):
         LIST_SIGNAL = create_simple_signal({"list_input": list})
         DICT_SIGNAL = create_simple_signal({"list_input": dict})
         with self.assertRaises(Exception):
             schema_from_signal(LIST_SIGNAL)
 
         with self.assertRaises(Exception):
-            schema_from_signal(DICT_SIGNAL)
-
-    def test_throw_exception_to_list_or_dict_types_without_annotation(self):
-        LIST_SIGNAL = create_simple_signal({"list_input": List})
-        DICT_SIGNAL = create_simple_signal({"list_input": Dict})
-        with self.assertRaises(TypeError):
-            schema_from_signal(LIST_SIGNAL)
-
-        with self.assertRaises(TypeError):
             schema_from_signal(DICT_SIGNAL)
 
     def test_list_with_annotation_works(self):

--- a/openedx_events/event_bus/avro/tests/test_schema.py
+++ b/openedx_events/event_bus/avro/tests/test_schema.py
@@ -239,11 +239,15 @@ class TestSchemaGeneration(TestCase):
     def test_throw_exception_to_list_or_dict_types_without_annotation(self):
         LIST_SIGNAL = create_simple_signal({"list_input": list})
         DICT_SIGNAL = create_simple_signal({"list_input": dict})
+        LIST_WITHOUT_ANNOTATION_SIGNAL = create_simple_signal({"list_input": List})
         with self.assertRaises(Exception):
             schema_from_signal(LIST_SIGNAL)
 
         with self.assertRaises(Exception):
             schema_from_signal(DICT_SIGNAL)
+
+        with self.assertRaises(TypeError):
+            schema_from_signal(LIST_WITHOUT_ANNOTATION_SIGNAL)
 
     def test_list_with_annotation_works(self):
         LIST_SIGNAL = create_simple_signal({"list_input": List[int]})

--- a/openedx_events/event_bus/avro/tests/test_schema.py
+++ b/openedx_events/event_bus/avro/tests/test_schema.py
@@ -1,6 +1,7 @@
 """
 Tests for event_bus.avro.schema module
 """
+from typing import Dict, List
 from unittest import TestCase
 
 from openedx_events.event_bus.avro.schema import schema_from_signal
@@ -243,3 +244,26 @@ class TestSchemaGeneration(TestCase):
 
         with self.assertRaises(Exception):
             schema_from_signal(DICT_SIGNAL)
+
+    def test_throw_exception_to_list_or_dict_types_without_annotation(self):
+        LIST_SIGNAL = create_simple_signal({"list_input": List})
+        DICT_SIGNAL = create_simple_signal({"list_input": Dict})
+        with self.assertRaises(TypeError):
+            schema_from_signal(LIST_SIGNAL)
+
+        with self.assertRaises(TypeError):
+            schema_from_signal(DICT_SIGNAL)
+
+    def test_list_with_annotation_works(self):
+        LIST_SIGNAL = create_simple_signal({"list_input": List[int]})
+        expected_dict = {
+            'name': 'CloudEvent',
+            'type': 'record',
+            'doc': 'Avro Event Format for CloudEvents created with openedx_events/schema',
+            'fields': [{
+                'name': 'list_input',
+                'type': {'type': 'array', 'items': 'long'},
+            }],
+        }
+        schema = schema_from_signal(LIST_SIGNAL)
+        self.assertDictEqual(schema, expected_dict)

--- a/openedx_events/event_bus/avro/types.py
+++ b/openedx_events/event_bus/avro/types.py
@@ -1,11 +1,14 @@
 """A mapping of python types to the Avro type that we want to use make valid avro schema."""
-PYTHON_TYPE_TO_AVRO_MAPPING = {
-    None: "null",
+SIMPLE_PYTHON_TYPE_TO_AVRO_MAPPING = {
     bool: "boolean",
     int: "long",
     float: "double",
     bytes: "bytes",
     str: "string",
+}
+PYTHON_TYPE_TO_AVRO_MAPPING = {
+    **SIMPLE_PYTHON_TYPE_TO_AVRO_MAPPING,
+    None: "null",
     dict: "record",
     list: "array",
 }

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -217,3 +217,21 @@ class PersistentCourseGradeData:
     percent_grade = attr.ib(type=float)
     letter_grade = attr.ib(type=str)
     passed_timestamp = attr.ib(type=datetime)
+
+
+@attr.s(frozen=True)
+class XBlockSkillVerificationData:
+    """
+    Data needed to update verification count  of tags/skills for an XBlock.
+
+    User feedback on whether tags/skills related to an XBlock are valid.
+
+    Arguments:
+        usage_key (UsageKey): identifier of the XBlock object.
+        verified_skills (List[int]): list of verified skill ids.
+        ignored_skills (List[int]): list of ignored skill ids.
+    """
+
+    usage_key = attr.ib(type=UsageKey)
+    verified_skills = attr.ib(type=List[int], factory=list)
+    ignored_skills = attr.ib(type=List[int], factory=list)

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -15,6 +15,7 @@ from openedx_events.learning.data import (
     CourseEnrollmentData,
     PersistentCourseGradeData,
     UserData,
+    XBlockSkillVerificationData,
 )
 from openedx_events.tooling import OpenEdxPublicSignal
 
@@ -146,5 +147,17 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.persistent_grade_summary.changed.v1",
     data={
         "grade": PersistentCourseGradeData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.xblock.skill.verified.v1
+# .. event_name: XBLOCK_SKILL_VERIFIED
+# .. event_description: Fired when an XBlock skill is verified.
+# .. event_data: XBlockSkillVerificationData
+XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.skill.verified.v1",
+    data={
+        "xblock_info": XBlockSkillVerificationData,
     }
 )


### PR DESCRIPTION
Adds data class and event to send skill verification data for an XBlock.

Updates avro serialization & de serialization just enough to support array types.

**Description:** The idea is that users will verify the tags/skills associated to an XBlock. We want to send this data via openedx-event signals to course-discovery and update the relevant tables.

**JIRA:** `Private-ref`: [BB-6885](https://tasks.opencraft.com/browse/BB-6885)

**Dependencies:** https://github.com/openedx/openedx-events/pull/143 

Original MR: https://github.com/open-craft/openedx-events/pull/1

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Only support for array type is added as it is required for this event.
