### PR TITLE
feat: updated event signal metadata time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 ----------
+Fixed
+~~~~~
+* Updated time metadata to include UTC timezone. The original implementation used utcnow(), which could give different results if the time were ever interpreted to be local time. See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
+
+Changed
+~~~~~~~
+* Updated send_event with an optional time argument to be used as metadata.
 
 [4.1.1] - 2023-01-23
 ---------------------

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -42,7 +42,9 @@ class EventsMetadata:
         time (datetime): (optional) timestamp when the event was sent with
             UTC timezone. Defaults to current time in UTC. See OEP-41 for
             details.
-        sourcelib (str): Open edX Events library version.
+        sourcelib (tuple of ints): Open edX Events library version. A tuple was
+            selected so that version comparisons don't have to worry about
+            lexical ordering of strings (e.g. '0.9.0' vs. '0.10.0').
     """
 
     id = attr.ib(type=UUID, init=False)

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -5,13 +5,24 @@ These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
 import socket
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID, uuid1
 
 import attr
 from django.conf import settings
 
 import openedx_events
+
+
+def _ensure_utc_time(_, attribute, value):
+    """
+    Ensure the value is a UTC datetime.
+
+    Note: Meant to be used along-side an instance_of attr validator.
+    """
+    if value.tzinfo and value.tzinfo == timezone.utc:
+        return
+    raise ValueError(f"'{attribute.name}' must have timezone.utc")
 
 
 @attr.s(frozen=True)
@@ -28,7 +39,9 @@ class EventsMetadata:
         minorversion (int): version of the event type.
         source (str): logical source of an event.
         sourcehost (str): physical source of the event.
-        time (datetime): timestamp when the event was sent.
+        time (datetime): (optional) timestamp when the event was sent with
+            UTC timezone. Defaults to current time in UTC. See OEP-41 for
+            details.
         sourcelib (str): Open edX Events library version.
     """
 
@@ -37,7 +50,13 @@ class EventsMetadata:
     minorversion = attr.ib(type=int, converter=attr.converters.default_if_none(0))
     source = attr.ib(type=str, init=False)
     sourcehost = attr.ib(type=str, init=False)
-    time = attr.ib(type=datetime, init=False)
+    current_utc_time = datetime.now(timezone.utc)
+    time = attr.ib(
+        type=datetime,
+        default=None,
+        converter=attr.converters.default_if_none(attr.Factory(lambda: datetime.now(timezone.utc))),
+        validator=attr.validators.optional([attr.validators.instance_of(datetime), _ensure_utc_time]),
+    )
     sourcelib = attr.ib(type=tuple, init=False)
 
     def __attrs_post_init__(self):
@@ -56,7 +75,6 @@ class EventsMetadata:
             ),
         )
         object.__setattr__(self, "sourcehost", socket.gethostname())
-        object.__setattr__(self, "time", datetime.utcnow())
         object.__setattr__(
             self, "sourcelib", tuple(map(int, openedx_events.__version__.split(".")))
         )

--- a/openedx_events/event_bus/tests/test_loader.py
+++ b/openedx_events/event_bus/tests/test_loader.py
@@ -109,5 +109,6 @@ class TestProducer(TestCase):
             # Nothing thrown, no warnings.
             assert producer.send(
                 signal=SESSION_LOGIN_COMPLETED, topic='user-logins',
-                event_key_field='user.id', event_data={}, event_metadata=EventsMetadata(event_type='eh', minorversion=0)
+                event_key_field='user.id', event_data={},
+                event_metadata=EventsMetadata(event_type='eh', minorversion=0)
             ) is None


### PR DESCRIPTION
**Description:**

* Updated time metadata to include UTC timezone. Original implementation used utcnow(), which could give different results if the time were ever
interpreted to be local time. See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
* Updated send_event to optionally take a time, which would be used for the metadata. Ideally, this will be explicitly set.

**ISSUE:**

* Implements first part of https://github.com/openedx/openedx-events/issues/162
* edx-platform will require an update to send the db time for the catalog event.
* event-bus-kafka will require passing on the time during event production.  
* Another change is needed in this library for `send_event_in_bus_consumer`, which will require an additional breaking change to EventsMetadata. That will likely be made in a separate branch and merged into this PR.

**Testing instructions:**

* Unit tests are probably enough for this change.
* The edx-platform and event-bus-kafka changes that will use this will be used to provide more end-to-end testing.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] ~~Version bumped~~
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Remove breaking change indicator from commit message

**Post merge:**
- [x] ~~Create a tag~~
- [x] ~~Check new version is pushed to PyPI after tag-triggered build is
      finished.~~
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 

I don't love how EventsMetadata is initialized with time that can be None, but this is how I think it needs to be done for the frozen attributes. Note, this pattern is going to be followed in the follow-up PR where all arguments need to be sent for event bus consumers.
