### PR TITLE
refactor: use collections.abc import to use with python 3.8 and 3.10

### DIFF
--- a/openedx_events/utils.py
+++ b/openedx_events/utils.py
@@ -28,7 +28,7 @@ class ResponsePrettyPrinter(PrettyPrinter):
                 exc_type, exc_value, exc_traceback
             )
             obj = "".join(exc_traceback_formatted)
-        if isinstance(obj, collections.Callable):
+        if isinstance(obj, collections.abc.Callable):
             obj = "{func_module}.{func_name}".format(
                 func_module=obj.__module__,
                 func_name=obj.__name__,


### PR DESCRIPTION
**Description:** This PR modified collections import for use with Python 3.10. Using or importing the ABCs from `collections` instead of from `collections.abc` is deprecated since Python 3.3, and in 3.10 it will stop working

**ISSUE:** https://github.com/openedx/openedx-events/issues/128

**Dependencies:** None

**Merge deadline:** None

**Installation instructions:** None

**Testing instructions:**

1. Clone this repo and use the branch
2. Create a viertual environment (use Python 3.8)
3. Run `make requirements`
4. Run `make validate`
5. Repeat steps 2, 3, 4 with python 3.10

**Reviewers:**
- [ ] @mariajgrimaldi
- [ ] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None
