### PR TITLE
fix: make minorversion actually optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Unreleased
 Fixed
 ~~~~~
 * Updated time metadata to include UTC timezone. The original implementation used utcnow(), which could give different results if the time were ever interpreted to be local time. See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
+* EventsMetadata minorversion is now fully optional, and doesn't need to be supplied when initializing to get the default of 0.
 
 Changed
 ~~~~~~~

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -36,7 +36,7 @@ class EventsMetadata:
     Arguments:
         id (UUID): event identifier.
         event_type (str): name of the event.
-        minorversion (int): version of the event type.
+        minorversion (int): (optional) version of the event type. Defaults to 0.
         source (str): logical source of an event.
         sourcehost (str): physical source of the event.
         time (datetime): (optional) timestamp when the event was sent with
@@ -49,7 +49,7 @@ class EventsMetadata:
 
     id = attr.ib(type=UUID, init=False)
     event_type = attr.ib(type=str)
-    minorversion = attr.ib(type=int, converter=attr.converters.default_if_none(0))
+    minorversion = attr.ib(type=int, default=None, converter=attr.converters.default_if_none(0))
     source = attr.ib(type=str, init=False)
     sourcehost = attr.ib(type=str, init=False)
     current_utc_time = datetime.now(timezone.utc)

--- a/openedx_events/event_bus/tests/test_loader.py
+++ b/openedx_events/event_bus/tests/test_loader.py
@@ -110,5 +110,5 @@ class TestProducer(TestCase):
             assert producer.send(
                 signal=SESSION_LOGIN_COMPLETED, topic='user-logins',
                 event_key_field='user.id', event_data={},
-                event_metadata=EventsMetadata(event_type='eh', minorversion=0)
+                event_metadata=EventsMetadata(event_type='eh')
             ) is None


### PR DESCRIPTION
**Description:**

You can now create an EventsMetadata instance
without supplying minorversion, and get the
default of 0.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] ~~Version bumped~~
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [x] ~~Create a tag~~
- [x] ~~Check new version is pushed to PyPI after tag-triggered build is
      finished.~~
- [x] Delete working branch (if not needed anymore)

