### PR TITLE
docs: bump version for patch release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[4.1.1] - 2023-01-23
+---------------------
+Changed
+~~~~~~~
+* Use collections.abc import to use with python 3.8 and 3.10.
+
 [4.1.0] - 2023-01-03
 ---------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 4.1.1
 commit = True
 tag = True
 


### PR DESCRIPTION
**Description:** 
This PR updates the openedx-events version for the latest patch release.