### PR TITLE
feat: add send_event_with_custom_metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 ----------
+
+[4.2.0] - 2023-01-24
+---------------------
+Added
+~~~~~~
+* Added ``send_event_with_custom_metadata``. This will enable event bus consumers to send the event signal with the same metadata fields that were used when the event was produced.
+
 Fixed
 ~~~~~
 * Updated time metadata to include UTC timezone. The original implementation used utcnow(), which could give different results if the time were ever interpreted to be local time. See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "4.1.1"
+__version__ = "4.2.0"


### PR DESCRIPTION
**Description:**

Added send_event_with_custom_metadata. This new version of send_event enables event bus consumers to send the event signal with the same metadata fields that were used when the event was produced.

**ISSUE:**

https://github.com/openedx/openedx-events/issues/162

**Testing instructions:**

Only tested via unit tests at this point. I could possibly make other PRs using these changes and pulling in openedx-events from this branch. But, it may be simpler to just release and fix forward if there are any issues, since no one else will be using the new method.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed (update comment with new name send_event_with_custom_metadata)

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)