### PR TITLE
test: Check that there are no data/metadata key collisions

### DIFF
--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -4,10 +4,6 @@ from unittest import TestCase
 
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-# Each new folder with signals must be manually imported in order for the signals to be cached
-#   and used in the unit tests. Using 'disable=reimported' with pylint will work,
-#   because we just use the cached signal list.
-from openedx_events.content_authoring import signals  # pylint: disable=unused-import
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer
 from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
 from openedx_events.event_bus.avro.tests.test_utilities import (
@@ -20,8 +16,7 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     deserialize_bytes_to_event_data,
     serialize_event_data_to_bytes,
 )
-from openedx_events.learning import signals  # See note above; pylint: disable=reimported
-from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.tests.utils import FreezeSignalCacheMixin, load_all_signals
 from openedx_events.tooling import OpenEdxPublicSignal
 
 # If a signal is explicitly not for use with the event bus, add it to this list
@@ -71,6 +66,13 @@ def generate_test_event_data_for_data_type(data_type):
 
 class TestAvro(FreezeSignalCacheMixin, TestCase):
     """Tests for end-to-end serialization and deserialization of events"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Ensure we can usefully call all_events()
+        load_all_signals()
+
     def test_all_events(self):
         for signal in OpenEdxPublicSignal.all_events():
             if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -1,0 +1,39 @@
+"""
+Tests for data.py.
+"""
+import attr
+import pytest
+from django.test import TestCase
+
+from openedx_events.data import EventsMetadata
+from openedx_events.tests.utils import load_all_signals
+from openedx_events.tooling import OpenEdxPublicSignal
+
+
+class EventsMetadataTestCache(TestCase):
+    """
+    Tests for EventsMetadata.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        load_all_signals()
+
+    def test_key_non_collision(self):
+        """
+        Check whether any events have a data key that collides with a metadata key.
+
+        This is important because both the data dict and the metadata dict get
+        splatted into the signal receiver, so we need to make sure none of the keys
+        collide.
+        """
+        metadata_fields = set(f.name for f in attr.fields(EventsMetadata))
+        for signal in OpenEdxPublicSignal.all_events():
+            for signal_root_key in signal.init_data.keys():
+                if signal_root_key in metadata_fields:
+                    pytest.fail(
+                        f"Signal {signal} has a root data key called {signal_root_key!r}, "
+                        "but this collides with an EventMetadata field. This signal will "
+                        "need to use a different key at the root of its data dictionary."
+                    )


### PR DESCRIPTION
This will ensure that no signals are added that conflict with metadata fields, or vice versa. Ensuring that there are no collisions will become important once the event bus consumer starts sending metadata to receivers.

**Merge checklist:**
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed