### PR TITLE
refactor!: move load_all_events to more visible location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[6.0.0] - 2023-02-23
+---------------------
+Changed
+~~~~~~~
+* **Breaking change**: Moved load_all_events() from openedx_events.tests.utils to openedx_events.tooling
+
 [5.1.0] - 2023-02-07
 ---------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "5.1.0"
+__version__ = "6.0.0"

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -17,8 +17,8 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     deserialize_bytes_to_event_data,
     serialize_event_data_to_bytes,
 )
-from openedx_events.tests.utils import FreezeSignalCacheMixin, load_all_signals
-from openedx_events.tooling import OpenEdxPublicSignal
+from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
 
 # If a signal is explicitly not for use with the event bus, add it to this list
 #  and document why in the event's annotations

--- a/openedx_events/tests/utils.py
+++ b/openedx_events/tests/utils.py
@@ -1,8 +1,6 @@
 """
 Utils used by Open edX event tests.
 """
-import pkgutil
-from importlib import import_module
 
 from openedx_events.tooling import OpenEdxPublicSignal
 
@@ -127,32 +125,3 @@ class OpenEdxEventsTestMixin(EventsIsolationMixin):
         cls().disable_all_events()
         cls().enable_events_by_type(*cls.ENABLED_OPENEDX_EVENTS)
         cls().allow_send_events_failure(*cls.ENABLED_OPENEDX_EVENTS)
-
-
-def load_all_signals():
-    """
-    Ensure OpenEdxPublicSignal.all_events() cache is fully populated.
-
-    Loads all non-test signals.py modules.
-    """
-    found = set()
-
-    root = import_module('openedx_events')
-    for m in pkgutil.walk_packages(root.__path__, root.__name__ + '.'):
-        module_name = m.name
-        if 'tests' in module_name.split('.') or '.test_' in module_name:
-            continue
-        if module_name.endswith('.signals'):
-            import_module(module_name)
-            found.add(module_name)
-
-    # Check that the auto-discovered list matches the known modules.
-    # This is just here to ensure that the auto-discovery is working
-    # properly and doesn't start to silently fail.
-    #
-    # If this assertion fails because a module has been added, renamed,
-    # or deleted, please update the hardcoded list.
-    assert found == {
-        'openedx_events.content_authoring.signals',
-        'openedx_events.learning.signals',
-    }

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -1,7 +1,9 @@
 """
 Tooling necessary to use Open edX events.
 """
+import pkgutil
 import warnings
+from importlib import import_module
 from logging import getLogger
 
 from django.conf import settings
@@ -252,3 +254,31 @@ class OpenEdxPublicSignal(Signal):
         More information on send_robust in the Django official documentation.
         """
         self._allow_send_event_failure = True
+
+
+def load_all_signals():
+    """
+    Ensure OpenEdxPublicSignal.all_events() cache is fully populated.
+    Loads all non-test signals.py modules.
+    """
+    found = set()
+
+    root = import_module('openedx_events')
+    for m in pkgutil.walk_packages(root.__path__, root.__name__ + '.'):
+        module_name = m.name
+        if 'tests' in module_name.split('.') or '.test_' in module_name:
+            continue
+        if module_name.endswith('.signals'):
+            import_module(module_name)
+            found.add(module_name)
+
+    # Check that the auto-discovered list matches the known modules.
+    # This is just here to ensure that the auto-discovery is working
+    # properly and doesn't start to silently fail.
+    #
+    # If this assertion fails because a module has been added, renamed,
+    # or deleted, please update the hardcoded list.
+    assert found == {
+        'openedx_events.content_authoring.signals',
+        'openedx_events.learning.signals',
+    }


### PR DESCRIPTION
**Description:**
Move load_all_events out of the test-only module to make it clear that it can be used by external apps that use openedx_events.

It seems a little bit silly to make this a breaking change but technically it would break anything that tried to use load_all_events. Nothing *should* be using it but we can't guarantee that.

**ISSUE:** https://github.com/openedx/event-bus-kafka/issues/135


**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.