### PR TITLE
feat: configurable loading of event bus consumer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,13 @@ Unreleased
   deprecated.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
   more details.
 
+[7.1.0] - 2023-04-24
+--------------------
+Added
+~~~~~
+* Configurable loader for consumer side of Event Bus in ``openedx_events.event_bus``.
+* Added management command to load configured consumer and start worker.
+
 [7.0.0] - 2023-03-07
 ---------------------
 Changed

--- a/manage.py
+++ b/manage.py
@@ -13,17 +13,10 @@ if __name__ == '__main__':
     sys.path.append(PWD)
     try:
         from django.core.management import execute_from_command_line
-    except ImportError:
-        # The above import may fail for some other reason. Ensure that the
-        # issue is really that Django is missing to avoid masking other
-        # exceptions on Python 2.
-        try:
-            import django  # pylint: disable=unused-import
-        except ImportError as exc:
-            raise ImportError(
-                'Couldn\'t import Django. Are you sure it\'s installed and '
-                'available on your PYTHONPATH environment variable? Did you '
-                'forget to activate a virtual environment?'
-            ) from exc
-        raise
+    except ImportError as exc:
+        raise ImportError(
+            'Couldn\'t import Django. Are you sure it\'s installed and '
+            'available on your PYTHONPATH environment variable? Did you '
+            'forget to activate a virtual environment?'
+        ) from exc
     execute_from_command_line(sys.argv)

--- a/manage.py
+++ b/manage.py
@@ -12,18 +12,18 @@ if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_utils.test_settings')
     sys.path.append(PWD)
     try:
-        from django.core.management import execute_from_command_line  # pylint: disable=wrong-import-position
+        from django.core.management import execute_from_command_line
     except ImportError:
         # The above import may fail for some other reason. Ensure that the
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
-        except ImportError:
+            import django  # pylint: disable=unused-import
+        except ImportError as exc:
             raise ImportError(
                 'Couldn\'t import Django. Are you sure it\'s installed and '
                 'available on your PYTHONPATH environment variable? Did you '
                 'forget to activate a virtual environment?'
-            )
+            ) from exc
         raise
     execute_from_command_line(sys.argv)

--- a/manage.py
+++ b/manage.py
@@ -11,3 +11,19 @@ PWD = os.path.abspath(os.path.dirname(__file__))
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_utils.test_settings')
     sys.path.append(PWD)
+    try:
+        from django.core.management import execute_from_command_line  # pylint: disable=wrong-import-position
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django  # pylint: disable=unused-import, wrong-import-position
+        except ImportError:
+            raise ImportError(
+                'Couldn\'t import Django. Are you sure it\'s installed and '
+                'available on your PYTHONPATH environment variable? Did you '
+                'forget to activate a virtual environment?'
+            )
+        raise
+    execute_from_command_line(sys.argv)

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "7.0.0"
+__version__ = "7.1.0"

--- a/openedx_events/apps.py
+++ b/openedx_events/apps.py
@@ -1,0 +1,13 @@
+"""
+openedx_events Django application initialization.
+"""
+
+from django.apps import AppConfig
+
+
+class OpenedxEventsConfig(AppConfig):
+    """
+    Configuration for the openedx_events Django application.
+    """
+
+    name = 'openedx_events'

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -1,7 +1,7 @@
 """
 Classes and utility functions for the event bus.
 
-This module includes the entry point for the producer.
+This module includes the entry points for the producer and consumer.
 
 API:
 
@@ -9,6 +9,9 @@ API:
   to the Event Bus. The backing implementation is chosen via the Django setting ``EVENT_BUS_PRODUCER``.
   See for example the Kafka implementation's ``KafkaEventProducer``, with the ``create_producer`` function
   serving as the loader: https://github.com/openedx/event-bus-kafka/blob/main/edx_event_bus_kafka/internal/producer.py
+- ``make_single_consumer`` creates an ``EventBusConsumer`` instance for a particular combination of
+  topic, consumer group, and signal. The backing implementation is chosen via the Django setting
+  ``EVENT_BUS_CONSUMER``.
 """
 
 import warnings
@@ -25,7 +28,7 @@ from openedx_events.data import EventsMetadata
 from openedx_events.tooling import OpenEdxPublicSignal
 
 
-def _try_load(*, setting_name: str, expected_class: type, default):
+def _try_load(*, setting_name: str, args: tuple, kwargs: dict, expected_class: type, default):
     """
     Load an instance of ``expected_class`` as indicated by ``setting_name``.
 
@@ -36,6 +39,8 @@ def _try_load(*, setting_name: str, expected_class: type, default):
 
     Arguments:
         setting_name: Name of a Django setting containing a dotted module path, indicating a callable
+        args: Tuple of positional arguments to pass to the callable
+        kwargs: Dictionary of keyword arguments to pass to the callable
         expected_class: The callable must produce an instance of this class object (or a subclass)
         default: Object to return if any part of the lookup or loading fails
     """
@@ -46,7 +51,7 @@ def _try_load(*, setting_name: str, expected_class: type, default):
 
     try:
         constructor = import_string(constructor_path)
-        instance = constructor()
+        instance = constructor(*args, **kwargs)
         if isinstance(instance, expected_class):
             return instance
         else:
@@ -116,8 +121,63 @@ def get_producer() -> EventBusProducer:
     If misconfigured, returns a fake implementation that can be called but does nothing.
     """
     return _try_load(
-        setting_name='EVENT_BUS_PRODUCER',
+        setting_name='EVENT_BUS_PRODUCER', args=(), kwargs={},
         expected_class=EventBusProducer, default=NoEventBusProducer(),
+    )
+
+
+class EventBusConsumer(ABC):
+    """
+    Parent class for event bus consumer implementations.
+    """
+
+    @abstractmethod
+    def consume_indefinitely(self) -> NoReturn:
+        """
+        Consume events from a topic in an infinite loop.
+
+        Events will be converted into calls to Django signals.
+        """
+
+
+class NoEventBusConsumer(EventBusConsumer):
+    """
+    Stub implementation to "load" when no implementation is properly configured.
+    """
+
+    def consume_indefinitely(self) -> NoReturn:
+        """Do nothing."""
+
+
+# .. setting_name: EVENT_BUS_CONSUMER
+# .. setting_default: None
+# .. setting_description: String naming a callable (function or class) that can be called to create
+#   or retrieve an instance of EventBusConsumer when ``openedx_events.event_bus.make_single_consumer`` is
+#   called. The format of the string is a dotted path to an attribute in a module, e.g.
+#   ``some.module.path.EventBusImplementation``. See docstring of ``make_single_consumer`` for
+#   parameters. If setting is not supplied or the callable raises an exception or does not return
+#   an instance of EventBusConsumer, calls to the consumer will be ignored with a warning at startup.
+
+
+def make_single_consumer(*, topic: str, group_id: str, signal: OpenEdxPublicSignal) -> EventBusConsumer:
+    """
+    Construct a consumer for a given topic, group, and signal.
+
+    If misconfigured, returns a fake implementation that does nothing.
+
+    Arguments:
+        topic: The event bus topic to consume from (without any environmental prefix)
+        group_id: The consumer group to participate in
+        signal: Send consumed, decoded events to the receivers of this signal
+    """
+    kwargs = {
+        'topic': topic,
+        'group_id': group_id,
+        'signal': signal,
+    }
+    return _try_load(
+        setting_name='EVENT_BUS_CONSUMER', args=(), kwargs=kwargs,
+        expected_class=EventBusConsumer, default=NoEventBusConsumer(),
     )
 
 

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -157,7 +157,7 @@ class NoEventBusConsumer(EventBusConsumer):
 #   an instance of EventBusConsumer, calls to the consumer will be ignored with a warning at startup.
 
 
-def make_single_consumer(*, topic: str, group_id: str, signal: OpenEdxPublicSignal) -> EventBusConsumer:
+def make_single_consumer(*, topic: str, group_id: str, signal: OpenEdxPublicSignal, **kwargs) -> EventBusConsumer:
     """
     Construct a consumer for a given topic, group, and signal.
 
@@ -168,13 +168,14 @@ def make_single_consumer(*, topic: str, group_id: str, signal: OpenEdxPublicSign
         group_id: The consumer group to participate in
         signal: Send consumed, decoded events to the receivers of this signal
     """
-    kwargs = {
+    options = {
         'topic': topic,
         'group_id': group_id,
         'signal': signal,
+        **kwargs,
     }
     return _try_load(
-        setting_name='EVENT_BUS_CONSUMER', args=(), kwargs=kwargs,
+        setting_name='EVENT_BUS_CONSUMER', args=(), kwargs=options,
         expected_class=EventBusConsumer, default=NoEventBusConsumer(),
     )
 

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -17,7 +17,6 @@ API:
 import warnings
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from typing import NoReturn, Optional
 
 from django.conf import settings
 from django.dispatch import receiver
@@ -73,7 +72,6 @@ class EventBusProducer(ABC):
     Parent class for event bus producer implementations.
     """
 
-    # TODO: Make event_metadata required (https://github.com/openedx/openedx-events/issues/153)
     @abstractmethod
     def send(
             self, *, signal: OpenEdxPublicSignal, topic: str, event_key_field: str, event_data: dict,
@@ -132,7 +130,7 @@ class EventBusConsumer(ABC):
     """
 
     @abstractmethod
-    def consume_indefinitely(self) -> NoReturn:
+    def consume_indefinitely(self) -> None:
         """
         Consume events from a topic in an infinite loop.
 
@@ -145,7 +143,7 @@ class NoEventBusConsumer(EventBusConsumer):
     Stub implementation to "load" when no implementation is properly configured.
     """
 
-    def consume_indefinitely(self) -> NoReturn:
+    def consume_indefinitely(self) -> None:
         """Do nothing."""
 
 

--- a/openedx_events/event_bus/tests/test_loader.py
+++ b/openedx_events/event_bus/tests/test_loader.py
@@ -112,3 +112,17 @@ class TestProducer(TestCase):
                 event_key_field='user.id', event_data={},
                 event_metadata=EventsMetadata(event_type='eh')
             ) is None
+
+
+class TestConsumer(TestCase):
+
+    @override_settings(EVENT_BUS_CONSUMER=None)
+    def test_default_does_nothing(self):
+        """
+        Test that the default is of the right class but does nothing.
+        """
+        consumer = make_single_consumer(topic="test", group_id="test", signal=SESSION_LOGIN_COMPLETED)
+
+        with assert_warnings([]):
+            # Nothing thrown, no warnings.
+            assert consumer.consume_indefinitely() is None

--- a/openedx_events/event_bus/tests/test_loader.py
+++ b/openedx_events/event_bus/tests/test_loader.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 from django.test import override_settings
 
 from openedx_events.data import EventsMetadata
-from openedx_events.event_bus import _try_load, get_producer
+from openedx_events.event_bus import _try_load, get_producer, make_single_consumer
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 
 
@@ -30,7 +30,7 @@ class TestLoader(TestCase):
     def test_unconfigured(self):
         with assert_warnings(["Event Bus setting DOES_NOT_EXIST is missing; component will be inactive"]):
             loaded = _try_load(
-                setting_name="DOES_NOT_EXIST",
+                setting_name="DOES_NOT_EXIST", args=(1), kwargs={'2': 3},
                 expected_class=dict, default={'def': 'ault'},
             )
         assert loaded == {'def': 'ault'}
@@ -39,10 +39,10 @@ class TestLoader(TestCase):
     def test_success(self):
         with assert_warnings([]):
             loaded = _try_load(
-                setting_name="EB_LOAD_PATH",
+                setting_name="EB_LOAD_PATH", args=(), kwargs={'2': 3},
                 expected_class=dict, default={'def': 'ault'},
             )
-        assert loaded == {}
+        assert loaded == {'2': 3}
 
     @override_settings(EB_LOAD_PATH='builtins.list')
     def test_wrong_type(self):
@@ -51,7 +51,7 @@ class TestLoader(TestCase):
                 "component will be inactive"
         ]):
             loaded = _try_load(
-                setting_name="EB_LOAD_PATH",
+                setting_name="EB_LOAD_PATH", args=([1, 2, 3],), kwargs={},
                 expected_class=dict, default={'def': 'ault'},
             )
         assert loaded == {'def': 'ault'}
@@ -64,7 +64,7 @@ class TestLoader(TestCase):
                 "component will be inactive"
         ]):
             loaded = _try_load(
-                setting_name="EB_LOAD_PATH",
+                setting_name="EB_LOAD_PATH", args=(1), kwargs={'2': 3},
                 expected_class=dict, default={'def': 'ault'},
             )
         assert loaded == {'def': 'ault'}
@@ -77,20 +77,20 @@ class TestLoader(TestCase):
                 "component will be inactive"
         ]):
             loaded = _try_load(
-                setting_name="EB_LOAD_PATH",
+                setting_name="EB_LOAD_PATH", args=(1), kwargs={'2': 3},
                 expected_class=dict, default={'def': 'ault'},
             )
         assert loaded == {'def': 'ault'}
 
-    @override_settings(EB_LOAD_PATH='builtins.len')
+    @override_settings(EB_LOAD_PATH='builtins.dict')
     def test_bad_args_for_callable(self):
         with assert_warnings([
                 "Failed to load <class 'dict'> from setting EB_LOAD_PATH: "
-                "TypeError('len() takes exactly one argument (0 given)'); "
+                "TypeError('type object argument after * must be an iterable, not int'); "
                 "component will be inactive"
         ]):
             loaded = _try_load(
-                setting_name="EB_LOAD_PATH",
+                setting_name="EB_LOAD_PATH", args=(1), kwargs={'2': 3},
                 expected_class=dict, default={'def': 'ault'},
             )
         assert loaded == {'def': 'ault'}

--- a/openedx_events/management/__init__.py
+++ b/openedx_events/management/__init__.py
@@ -1,0 +1,3 @@
+"""
+Management commands for openedx_events.
+"""

--- a/openedx_events/management/commands/__init__.py
+++ b/openedx_events/management/commands/__init__.py
@@ -1,0 +1,5 @@
+"""
+Management commands for the Openedx events.
+
+(Django requires this package structure.)
+"""

--- a/openedx_events/management/commands/consume_events.py
+++ b/openedx_events/management/commands/consume_events.py
@@ -22,15 +22,15 @@ class Command(BaseCommand):
 
     Example::
 
-        python3 manage.py consume_events -t user-login -g user-activity-service \
+        python manage.py consume_events -t user-login -g user-activity-service \
             -s org.openedx.learning.auth.session.login.completed.v1
 
         # send extra args, for example pass check_backlog flag to redis consumer
-        python3 manage.py cms consume_events -t user-login -g user-activity-service \
+        python manage.py cms consume_events -t user-login -g user-activity-service \
             -s org.openedx.learning.auth.session.login.completed.v1 --extra '{"check_backlog": true}'
 
         # send extra args, for example replay events from specific redis msg id.
-        python3 manage.py cms consume_events -t user-login -g user-activity-service \
+        python manage.py cms consume_events -t user-login -g user-activity-service \
             -s org.openedx.learning.auth.session.login.completed.v1 \
             --extra '{"last_read_msg_id": "1679676448892-0"}'
     """
@@ -45,7 +45,6 @@ class Command(BaseCommand):
             required=True,
             help='Topic to consume (without environment prefix)'
         )
-
         parser.add_argument(
             '-g', '--group_id',
             nargs=1,
@@ -71,6 +70,7 @@ class Command(BaseCommand):
         Create consumer based on django settings and consume events.
         """
         try:
+            # load additional arguments specific for the underlying implementation of event_bus.
             extra = json.loads(options.get('extra') or '{}')
             load_all_signals()
             signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])

--- a/openedx_events/management/commands/consume_events.py
+++ b/openedx_events/management/commands/consume_events.py
@@ -1,0 +1,58 @@
+"""
+Makes ``consume_events`` management command available.
+"""
+import logging
+from django.core.management.base import BaseCommand
+from openedx_events.event_bus import make_single_consumer
+
+from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command for consumer workers in the event bus.
+    """
+    help = """
+    Consume messages of specified signal type from a topic and send their data to that signal.
+
+    Example::
+
+        python3 manage.py consume_events -t user-login -g user-activity-service \
+            -s org.openedx.learning.auth.session.login.completed.v1
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-t', '--topic',
+            nargs=1,
+            required=True,
+            help='Topic to consume (without environment prefix)'
+        )
+
+        parser.add_argument(
+            '-g', '--group_id',
+            nargs=1,
+            required=True,
+            help='Consumer group id'
+        )
+        parser.add_argument(
+            '-s', '--signal',
+            nargs=1,
+            required=True,
+            help='Type of signal to emit from consumed messages.'
+        )
+
+    def handle(self, *args, **options):
+        try:
+            load_all_signals()
+            signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])
+            event_consumer = make_single_consumer(
+                topic=options['topic'][0],
+                group_id=options['group_id'][0],
+                signal=signal,
+            )
+            event_consumer.consume_indefinitely()
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Error consuming events")

--- a/openedx_events/management/commands/consume_events.py
+++ b/openedx_events/management/commands/consume_events.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             nargs='?',
             type=str,
             required=False,
-            help='JSON string to pass additional arguments to the consumer.'
+            help='JSON object to pass additional arguments to the consumer.'
         )
 
     def handle(self, *args, **options):

--- a/openedx_events/tests/test_consume_events_command.py
+++ b/openedx_events/tests/test_consume_events_command.py
@@ -17,12 +17,24 @@ class TestCommand(TestCase):
     @patch('openedx_events.tooling.OpenEdxPublicSignal.get_signal_by_type', return_value="test-signal")
     @patch('openedx_events.management.commands.consume_events.make_single_consumer', autospec=True)
     def test_consumer_call_with_only_required_args(self, mock_make_consumer, _):
+        """
+        This methods checks the required args are correctly passed to consumer.
+
+        Expected behavior:
+            The required args are passed to consumer.
+        """
         call_command(Command(), topic=['test'], group_id=['test'], signal=['test-signal'])
         mock_make_consumer.assert_called_once_with(topic='test', group_id='test', signal='test-signal')
 
     @patch('openedx_events.tooling.OpenEdxPublicSignal.get_signal_by_type', return_value="test-signal")
     @patch('openedx_events.management.commands.consume_events.make_single_consumer', autospec=True)
     def test_consumer_call_with_extra_args(self, mock_make_consumer, _):
+        """
+        This methods checks the extra args are correctly parsed and passed to consumer.
+
+        Expected behavior:
+            The extra args are parsed and passed to consumer.
+        """
         call_command(
             Command(),
             topic=['test'],
@@ -40,6 +52,12 @@ class TestCommand(TestCase):
     @patch('openedx_events.management.commands.consume_events.logger', autospec=True)
     @patch('openedx_events.management.commands.consume_events.make_single_consumer', autospec=True)
     def test_consumer_call_with_incorrect_json_string(self, mock_make_consumer, mock_logger):
+        """
+        This methods checks that consumer is not called with incorrect args if extra args json is incorrectly formed.
+
+        Expected behavior:
+            The command logs and skips execution if extra args json is incorrectly formed.
+        """
         call_command(
             Command(),
             topic=['test'],

--- a/openedx_events/tests/test_consume_events_command.py
+++ b/openedx_events/tests/test_consume_events_command.py
@@ -1,0 +1,51 @@
+"""
+Tests for consume_events command.
+"""
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from openedx_events.management.commands.consume_events import Command
+
+
+class TestCommand(TestCase):
+    """
+    Tests for the consume_events management command
+    """
+
+    @patch('openedx_events.tooling.OpenEdxPublicSignal.get_signal_by_type', return_value="test-signal")
+    @patch('openedx_events.management.commands.consume_events.make_single_consumer', autospec=True)
+    def test_consumer_call_with_only_required_args(self, mock_make_consumer, _):
+        call_command(Command(), topic=['test'], group_id=['test'], signal=['test-signal'])
+        mock_make_consumer.assert_called_once_with(topic='test', group_id='test', signal='test-signal')
+
+    @patch('openedx_events.tooling.OpenEdxPublicSignal.get_signal_by_type', return_value="test-signal")
+    @patch('openedx_events.management.commands.consume_events.make_single_consumer', autospec=True)
+    def test_consumer_call_with_extra_args(self, mock_make_consumer, _):
+        call_command(
+            Command(),
+            topic=['test'],
+            group_id=['test'],
+            signal=['test-signal'],
+            extra='{"check_backlog":true}'
+        )
+        mock_make_consumer.assert_called_once_with(
+            topic='test',
+            group_id='test',
+            signal='test-signal',
+            check_backlog=True
+        )
+
+    @patch('openedx_events.management.commands.consume_events.logger', autospec=True)
+    @patch('openedx_events.management.commands.consume_events.make_single_consumer', autospec=True)
+    def test_consumer_call_with_incorrect_json_string(self, mock_make_consumer, mock_logger):
+        call_command(
+            Command(),
+            topic=['test'],
+            group_id=['test'],
+            signal=['test-signal'],
+            extra="{'check_backlog':true}"
+        )
+        mock_logger.exception.assert_called_once_with("Error consuming events")
+        mock_make_consumer.assert_not_called()


### PR DESCRIPTION
**Description:** This defines an API for IDAs to use when consuming events that allows the choice of Event Bus implementation to be configured rather than written in code. 

It also includes a management command to start a worker and allows to pass in extra arguments for the underlying implementation of event bus.

**ISSUE:** #147 

**Dependencies:** None

**Merge deadline:** List merge deadline (if any)

**Testing instructions:**

Please refer to https://github.com/openedx/event-bus-redis/pull/13 for testing instructions.

**Reviewers:**
- [ ] @kaustavb12
- [ ] @bmtcril 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** The management command implement in [event-bus-kafka takes in an argument](https://github.com/openedx/event-bus-kafka/blob/3f0804234449bd1393198896db104f1f93743b7b/edx_event_bus_kafka/internal/consumer.py#L646-L649) called `offset_time` and calls a different method i.e. calls `reset_offsets_and_sleep_indefinitely` instead of `consume_indefinitely`. If this MR is accepted, we will need to change the implementation and set the argument `offset_time` in the class and move this [logic](https://github.com/openedx/event-bus-kafka/blob/3f0804234449bd1393198896db104f1f93743b7b/edx_event_bus_kafka/internal/consumer.py#L646-L649) inside `consume_indefinitely`.
