### PR TITLE
fix: Remove yanked codecov package to unbreak dev; upgrade GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run coverage
         if: matrix.python-version == '3.8' && matrix.toxenv == 'py38'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           flags: unittests
           fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.3
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==23.0
     # via tox
 platformdirs==3.2.0
@@ -28,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -38,7 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,7 +25,6 @@ build==0.10.0
     #   pip-tools
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 cffi==1.15.1
@@ -36,7 +35,6 @@ chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.3
@@ -55,13 +53,9 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 cryptography==40.0.1
     # via
@@ -104,7 +98,6 @@ filelock==3.11.0
     #   virtualenv
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 importlib-metadata==6.2.1
@@ -270,9 +263,7 @@ readme-renderer==37.3
     #   twine
 requests==2.28.2
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   requests-toolbelt
     #   twine
 requests-toolbelt==0.10.1
@@ -347,7 +338,6 @@ typing-extensions==4.5.0
     #   rich
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   twine


### PR DESCRIPTION
This fixes `make requirements`. Upgrading the GHA while I'm at it.

https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
