### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
+  deprecated.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
+  more details.
+
 [7.0.0] - 2023-03-07
 ---------------------
 Changed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 html_theme = 'sphinx_book_theme'
 
 html_theme_options = {
-
     "repository_url": "https://github.com/openedx/openedx-events",
     "repository_branch": "main",
     "path_to_docs": "docs/",
@@ -84,7 +83,7 @@ html_theme_options = {
                 href="https://openedx.org"
                 property="cc:attributionName"
                 rel="cc:attributionURL"
-            >The Center for Reimagining Learning</a>
+            >Axim Collaborative, Inc</a>
         are licensed under a
             <a
                 rel="license"
@@ -97,8 +96,8 @@ html_theme_options = {
 # bug in the theme that needs to be fixed first.
 # If you'd like you can temporarily copy the logo file to your `_static`
 # directory.
-html_logo = "_static/open-edx-logo-color.png"
-html_favicon = "_static/open-edx-favicon.ico"
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,7 +4,7 @@
 -r test.txt               # Core and testing dependencies for this package
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
+sphinx-book-theme         # Common theme for all Open edX projects
 build                     # Needed for twine command
 twine                     # Utility for publishing Python packages on PyPI.
 sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -59,8 +59,6 @@ docutils==0.19
     #   sphinx
 edx-opaque-keys[django]==2.3.0
     # via -r requirements/test.txt
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -184,7 +182,6 @@ secretstorage==3.3.3
 six==1.16.0
     # via
     #   bleach
-    #   edx-sphinx-theme
     #   livereload
 snowballstemmer==2.2.0
     # via sphinx
@@ -194,7 +191,6 @@ sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
     #   pydata-sphinx-theme
     #   sphinx-autobuild
     #   sphinx-book-theme


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:**
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/edx-sphinx-theme/issues/184