### PR TITLE
Adding dependabot as part of the maintainers protocol

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
**Description:** This PR adds a .github/dependabot.yml file to bring the repo up to day with the maintainers program

**Dependencies:** None

**Merge deadline:** None, but hopefully soon

**Installation instructions:** None, it's all done by github

**Testing instructions:**

Not easy to test. Must wait until dependabot actually opens a PR updating the actions.
See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

**Reviewers:**
- [ ] @mariajgrimaldi 


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] N/A Version bumped
- [ ] Changelog record added
- [x] N/A Documentation updated (not only docstrings)
- [x] N/A Commits are squashed

**Post merge:**
- [x] N/A Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [x] N/A Delete working branch (if not needed anymore)

**Author concerns:** Do we need to add this, or by having it in https://github.com/openedx/.github/blob/master/.github/dependabot.yml it is already running?
