### PR TITLE
feat!: remove signal argument from consumer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 --------------------
 Changed
 ~~~~~~~
-* **Breaking change**: Remove `signal` argument from consume_events and make_single_consumer
+* **Breaking change**: Remove ``signal`` argument from consume_events and make_single_consumer
 
 [7.3.0] - 2023-05-15
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[8.0.0] - 2023-05-16
+--------------------
+Changed
+~~~~~~~
+* **Breaking change**: Remove `signal` argument from consume_events and make_single_consumer
+
 [7.3.0] - 2023-05-15
 --------------------
 Changed

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "7.3.0"
+__version__ = "8.0.0"

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -158,7 +158,6 @@ class NoEventBusConsumer(EventBusConsumer):
 
 
 def make_single_consumer(*, topic: str, group_id: str,
-                         signal: OpenEdxPublicSignal = None,  # pylint: disable=unused-argument
                          **kwargs) -> EventBusConsumer:
     """
     Construct a consumer for a given topic, group, and signal.
@@ -168,7 +167,6 @@ def make_single_consumer(*, topic: str, group_id: str,
     Arguments:
         topic: The event bus topic to consume from (without any environmental prefix)
         group_id: The consumer group to participate in
-        signal: DEPRECATED This argument will be ignored. Signals will be determined by message headers
     """
     options = {
         'topic': topic,

--- a/openedx_events/management/commands/consume_events.py
+++ b/openedx_events/management/commands/consume_events.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
     """
 
     help = """
-    Consume messages of specified signal type from a topic and send their data to that signal.
+    Consume messages from a topic and emit their data with the correct signal.
 
     Example::
 
@@ -34,7 +34,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """
-        Add arguments for parsing topic, group, signal and extra args.
+        Add arguments for parsing topic, group, and extra args.
         """
         parser.add_argument(
             '-t', '--topic',
@@ -47,12 +47,6 @@ class Command(BaseCommand):
             nargs=1,
             required=True,
             help='Consumer group id'
-        )
-        parser.add_argument(
-            '-s', '--signal',
-            nargs=1,
-            required=False,
-            help='DEPRECATED This argument will be ignored. Signals will be determined by message headers'
         )
         parser.add_argument(
             '--extra',


### PR DESCRIPTION
**Description:**
Removes the deprecated and unused 'signal' argument from consume_events and the underlying consumer abstract class.

**ISSUE:** https://github.com/openedx/openedx-events/issues/218

**Dependencies:** 
(private link) https://github.com/edx/edx-internal/pull/8382

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.