### PR TITLE
feat: add unit tests around schema evolution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[8.1.0] - 2023-06-06
+--------------------
+Added
+~~~~~
+* Store current versions of Avro schemas and add test to ensure valid evolution
+
 [8.0.1] - 2023-05-16
 --------------------
 Changed

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "8.0.1"
+__version__ = "8.1.0"

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+course+catalog_info+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+course+catalog_info+changed+v1_schema.avsc
@@ -1,0 +1,74 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "catalog_info",
+      "type": {
+        "name": "CourseCatalogData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "course_key",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "schedule_data",
+            "type": {
+              "name": "CourseScheduleData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "start",
+                  "type": "string"
+                },
+                {
+                  "name": "pacing",
+                  "type": "string"
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "enrollment_start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "enrollment_end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "hidden",
+            "type": "boolean"
+          },
+          {
+            "name": "invitation_only",
+            "type": "boolean"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.course.catalog_info.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+deleted+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+deleted+v1_schema.avsc
@@ -1,0 +1,25 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "xblock_info",
+      "type": {
+        "name": "XBlockData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "usage_key",
+            "type": "string"
+          },
+          {
+            "name": "block_type",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.xblock.deleted.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+duplicated+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+duplicated+v1_schema.avsc
@@ -1,0 +1,29 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "xblock_info",
+      "type": {
+        "name": "DuplicatedXBlockData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "usage_key",
+            "type": "string"
+          },
+          {
+            "name": "block_type",
+            "type": "string"
+          },
+          {
+            "name": "source_usage_key",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.xblock.duplicated.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+published+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+published+v1_schema.avsc
@@ -1,0 +1,25 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "xblock_info",
+      "type": {
+        "name": "XBlockData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "usage_key",
+            "type": "string"
+          },
+          {
+            "name": "block_type",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.xblock.published.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+skill+verified+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+skill+verified+v1_schema.avsc
@@ -1,0 +1,35 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "xblock_info",
+      "type": {
+        "name": "XBlockSkillVerificationData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "usage_key",
+            "type": "string"
+          },
+          {
+            "name": "verified_skills",
+            "type": {
+              "type": "array",
+              "items": "long"
+            }
+          },
+          {
+            "name": "ignored_skills",
+            "type": {
+              "type": "array",
+              "items": "long"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.xblock.skill.verified.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+auth+session+login+completed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+auth+session+login+completed+v1_schema.avsc
@@ -1,0 +1,46 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "user",
+      "type": {
+        "name": "UserData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "long"
+          },
+          {
+            "name": "is_active",
+            "type": "boolean"
+          },
+          {
+            "name": "pii",
+            "type": {
+              "name": "UserPersonalData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "username",
+                  "type": "string"
+                },
+                {
+                  "name": "email",
+                  "type": "string"
+                },
+                {
+                  "name": "name",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.auth.session.login.completed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+certificate+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+certificate+changed+v1_schema.avsc
@@ -1,0 +1,112 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "certificate",
+      "type": {
+        "name": "CertificateData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "type": "string"
+          },
+          {
+            "name": "grade",
+            "type": "string"
+          },
+          {
+            "name": "download_url",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "current_status",
+            "type": "string"
+          },
+          {
+            "name": "previous_status",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.certificate.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+certificate+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+certificate+created+v1_schema.avsc
@@ -1,0 +1,112 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "certificate",
+      "type": {
+        "name": "CertificateData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "type": "string"
+          },
+          {
+            "name": "grade",
+            "type": "string"
+          },
+          {
+            "name": "download_url",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "current_status",
+            "type": "string"
+          },
+          {
+            "name": "previous_status",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.certificate.created.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+certificate+revoked+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+certificate+revoked+v1_schema.avsc
@@ -1,0 +1,112 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "certificate",
+      "type": {
+        "name": "CertificateData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "type": "string"
+          },
+          {
+            "name": "grade",
+            "type": "string"
+          },
+          {
+            "name": "download_url",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "current_status",
+            "type": "string"
+          },
+          {
+            "name": "previous_status",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.certificate.revoked.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+cohort_membership+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+cohort_membership+changed+v1_schema.avsc
@@ -1,0 +1,92 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "cohort",
+      "type": {
+        "name": "CohortData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.cohort_membership.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+enrollment+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+enrollment+changed+v1_schema.avsc
@@ -1,0 +1,108 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "enrollment",
+      "type": {
+        "name": "CourseEnrollmentData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "type": "string"
+          },
+          {
+            "name": "is_active",
+            "type": "boolean"
+          },
+          {
+            "name": "creation_date",
+            "type": "string"
+          },
+          {
+            "name": "created_by",
+            "type": [
+              "null",
+              "UserData"
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.course.enrollment.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+enrollment+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+enrollment+created+v1_schema.avsc
@@ -1,0 +1,108 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "enrollment",
+      "type": {
+        "name": "CourseEnrollmentData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "type": "string"
+          },
+          {
+            "name": "is_active",
+            "type": "boolean"
+          },
+          {
+            "name": "creation_date",
+            "type": "string"
+          },
+          {
+            "name": "created_by",
+            "type": [
+              "null",
+              "UserData"
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.course.enrollment.created.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_grade_summary+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_grade_summary+changed+v1_schema.avsc
@@ -1,0 +1,78 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "grade",
+      "type": {
+        "name": "PersistentCourseGradeData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user_id",
+            "type": "long"
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "course_edited_timestamp",
+            "type": "string"
+          },
+          {
+            "name": "course_version",
+            "type": "string"
+          },
+          {
+            "name": "grading_policy_hash",
+            "type": "string"
+          },
+          {
+            "name": "percent_grade",
+            "type": "double"
+          },
+          {
+            "name": "letter_grade",
+            "type": "string"
+          },
+          {
+            "name": "passed_timestamp",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.course.persistent_grade_summary.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+unenrollment+completed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+unenrollment+completed+v1_schema.avsc
@@ -1,0 +1,108 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "enrollment",
+      "type": {
+        "name": "CourseEnrollmentData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "mode",
+            "type": "string"
+          },
+          {
+            "name": "is_active",
+            "type": "boolean"
+          },
+          {
+            "name": "creation_date",
+            "type": "string"
+          },
+          {
+            "name": "created_by",
+            "type": [
+              "null",
+              "UserData"
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.course.unenrollment.completed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+student+registration+completed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+student+registration+completed+v1_schema.avsc
@@ -1,0 +1,46 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "user",
+      "type": {
+        "name": "UserData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "long"
+          },
+          {
+            "name": "is_active",
+            "type": "boolean"
+          },
+          {
+            "name": "pii",
+            "type": {
+              "name": "UserPersonalData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "username",
+                  "type": "string"
+                },
+                {
+                  "name": "email",
+                  "type": "string"
+                },
+                {
+                  "name": "name",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.student.registration.completed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+xblock+skill+verified+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+xblock+skill+verified+v1_schema.avsc
@@ -31,5 +31,5 @@
       }
     }
   ],
-  "namespace": "org.openedx.content_authoring.xblock.skill.verified.v1"
+  "namespace": "org.openedx.learning.xblock.skill.verified.v1"
 }

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -197,10 +197,7 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
 
         Caveat: While we can go from an attrs class to a schema, we cannot go from a schema to an attrs class in the
         same way because of custom serializers. Thus, when we are generating test data, we can only generate
-        it using the latest version of the attrs class, and not one derived from the stored schema. This means this
-        test does not perfectly reflect what would happen if the consumer was updated before the producer, but it still
-        fails if the latest attrs class is not backward compatible with the old schema. It will just fail on writing
-        instead of reading.
+        the dictionary we would get after calling schema.to_dict.
         """
         for signal in OpenEdxPublicSignal.all_events():
             if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -1,8 +1,12 @@
 """Test interplay of the various Avro helper classes"""
+import io
+import os
 from datetime import datetime
 from typing import List
 from unittest import TestCase
 
+from fastavro import schemaless_reader, schemaless_writer
+from fastavro.schema import load_schema
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer, deserialize_bytes_to_event_data
@@ -16,15 +20,7 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     create_simple_signal,
 )
 from openedx_events.tests.utils import FreezeSignalCacheMixin
-from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
-
-# If a signal is explicitly not for use with the event bus, add it to this list
-#  and document why in the event's annotations
-KNOWN_UNSERIALIZABLE_SIGNALS = [
-    "org.openedx.learning.discussions.configuration.changed.v1",
-    "org.openedx.content_authoring.course.certificate_config.changed.v1",
-    "org.openedx.content_authoring.course.certificate_config.deleted.v1",
-]
+from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
 
 
 def generate_test_event_data_for_data_type(data_type):
@@ -40,7 +36,6 @@ def generate_test_event_data_for_data_type(data_type):
     Returns:
         (dict): A data dictionary containing dummy data for all attributes of the class
     """
-    data_dict = {}
     defaults_per_type = {
         int: 1,
         bool: True,
@@ -53,6 +48,7 @@ def generate_test_event_data_for_data_type(data_type):
         List[int]: [1, 2, 3],
         datetime: datetime.now(),
     }
+    data_dict = {}
     for attribute in data_type.__attrs_attrs__:
         result = defaults_per_type.get(attribute.type, None)
         if result is not None:
@@ -65,8 +61,29 @@ def generate_test_event_data_for_data_type(data_type):
     return data_dict
 
 
+def generate_test_data_for_signal(signal: OpenEdxPublicSignal) -> dict:
+    """
+    Generates test data for use in the event bus test cases.
+
+    Builds data by filling in dummy data for basic data types (int/float/bool/str)
+    and recursively breaks down the classes for nested classes into basic data types.
+
+    Arguments:
+        data_type: The type of the data which we are generating data for
+
+    Returns:
+        (dict): A data dictionary containing dummy data for all attributes of the class
+    """
+    test_data = {}
+    for key, curr_class in signal.init_data.items():
+        example_data = generate_test_event_data_for_data_type(curr_class)
+        example_data_processed = curr_class(**example_data)
+        test_data.update({key: example_data_processed})
+    return test_data
+
+
 class TestAvro(FreezeSignalCacheMixin, TestCase):
-    """Tests for end-to-end serialization and deserialization of events"""
+    """Tests for end-to-end serialization and deserialization of events and schema evolution"""
 
     @classmethod
     def setUpClass(cls):
@@ -78,16 +95,79 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
         for signal in OpenEdxPublicSignal.all_events():
             if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:
                 continue
-            test_data = {}
+            test_data = generate_test_data_for_signal(signal)
             serializer = AvroSignalSerializer(signal)
-            for key, curr_class in signal.init_data.items():
-                example_data = generate_test_event_data_for_data_type(curr_class)
-                example_data_processed = curr_class(**example_data)
-                test_data.update({key: example_data_processed})
             serialized = serializer.to_dict(test_data)
             deserializer = AvroSignalDeserializer(signal)
             deserialized = deserializer.from_dict(serialized)
             self.assertDictEqual(deserialized, test_data)
+
+    def test_evolution_is_forward_compatible(self):
+        """
+        Test current version of events is forward compatible with stored schemas.
+
+        There's no assert because as long as the test doesn't raise an error, the new schema is
+        forward-compatible with the original.
+        """
+        for signal in OpenEdxPublicSignal.all_events():
+            if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:
+                continue
+            test_data = generate_test_data_for_signal(signal)
+            serializer = AvroSignalSerializer(signal)
+            schema_dict = serializer.schema
+
+            # write to bytes using current schema
+            current_out = io.BytesIO()
+            data_dict = serializer.to_dict(test_data)
+            schemaless_writer(current_out, schema_dict, data_dict)
+            current_out.seek(0)
+            current_event_bytes = current_out.read()
+
+            # get stored schema
+            stored_schema = load_schema(f"{os.path.dirname(os.path.abspath(__file__))}/schemas/"
+                                        f"{signal.event_type.replace('.','+')}_schema.avsc")
+
+            data_file_current = io.BytesIO(current_event_bytes)
+
+            # read bytes using stored schema
+            schemaless_reader(data_file_current, reader_schema=stored_schema, writer_schema=schema_dict)
+
+    def test_evolution_is_backward_compatible(self):
+        """
+        Test current version of events is backward compatible with stored schemas.
+
+        There's no assert because as long as the test doesn't raise an error, the new schema is
+        backward-compatible with the original.
+
+        Caveat: While we can go from an attrs class to a schema, we cannot go from a schema to an attrs class in the
+        same way because of custom serializers. Thus, when we are generating test data, we can only generate
+        it using the latest version of the attrs class, and not one derived from the stored schema. This means this
+        test does not perfectly reflect what would happen if the consumer was updated before the producer, but it still
+        fails if the latest attrs class is not backward compatible with the old schema. It will just fail on writing
+        instead of reading.
+        """
+        for signal in OpenEdxPublicSignal.all_events():
+            if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:
+                continue
+            test_data = generate_test_data_for_signal(signal)
+            serializer = AvroSignalSerializer(signal)
+            schema_dict = serializer.schema
+            data_dict = serializer.to_dict(test_data)
+
+            # get stored schema
+            old_schema = load_schema(f"{os.path.dirname(os.path.abspath(__file__))}/schemas/"
+                                     f"{signal.event_type.replace('.','+')}_schema.avsc")
+
+            # write to bytes using stored schema
+            stored_out = io.BytesIO()
+            schemaless_writer(stored_out, old_schema, data_dict)
+            stored_out.seek(0)
+            stored_event_bytes = stored_out.read()
+
+            data_file_stored = io.BytesIO(stored_event_bytes)
+
+            # read bytes using current schema
+            schemaless_reader(data_file_stored, reader_schema=schema_dict, writer_schema=old_schema)
 
     def test_full_serialize_deserialize(self):
         SIGNAL = create_simple_signal({"test_data": EventData})

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -6,8 +6,8 @@ from typing import List
 from unittest import TestCase
 
 from fastavro import schemaless_reader, schemaless_writer
-from fastavro.schema import load_schema
 from fastavro.repository.base import SchemaRepositoryError
+from fastavro.schema import load_schema
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer, deserialize_bytes_to_event_data

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -185,7 +185,7 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
                               f"{signal.event_type.replace('.','+')}_schema.avsc"
             try:
                 stored_schema = load_schema(schema_filename)
-            except SchemaRepositoryError:
+            except SchemaRepositoryError:  # pragma: no cover
                 self.fail(f"Missing file {schema_filename}. If a new signal has been added, you may need to run the"
                           f" generate_avro_schemas management command to save the signal schema.")
 
@@ -216,7 +216,7 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
                               f"{signal.event_type.replace('.','+')}_schema.avsc"
             try:
                 old_schema = load_schema(schema_filename)
-            except SchemaRepositoryError:
+            except SchemaRepositoryError:  # pragma: no cover
                 self.fail(f"Missing file {schema_filename}. If a new signal has been added, you may need to run the"
                           f" generate_avro_schemas management command to save the signal schema.")
             data_dict = generate_test_data_for_schema(old_schema)

--- a/openedx_events/event_bus/avro/tests/test_utilities.py
+++ b/openedx_events/event_bus/avro/tests/test_utilities.py
@@ -14,15 +14,16 @@ from openedx_events.event_bus.avro.types import PYTHON_TYPE_TO_AVRO_MAPPING
 from openedx_events.tooling import OpenEdxPublicSignal
 
 
-def create_simple_signal(data_dict):
+def create_simple_signal(data_dict, event_type="simple.signal"):
     """
     Create a basic OpenEdxPublicSignal with init_data = data_dict.
 
     Arguments:
         data_dict: Description of attributes passed to the signal
+        event_type: A custom event type string. Defaults to 'simple.signal'
     """
     return OpenEdxPublicSignal(
-        event_type="simple.signal",
+        event_type=event_type,
         data=data_dict
     )
 

--- a/openedx_events/management/commands/generate_avro_schemas.py
+++ b/openedx_events/management/commands/generate_avro_schemas.py
@@ -1,0 +1,89 @@
+"""
+Management command to generate and store Avro schemas for testing.
+"""
+import json
+import logging
+import os
+from importlib import import_module
+
+from django.core.management.base import BaseCommand
+
+from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
+from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command to save current Avro schemas for all signals for schema evolution testing.
+    """
+
+    help = """
+    Generate and save the current Avro schemas of OpenEdxPublicSignals.
+
+    Schemas will be saved in openedx_events/avro/tests/schemas. The folder will be created if it does not already exist.
+    Should only be used for new signals. Existing files will be overwritten, so use with caution.
+
+    Example::
+
+        # one signal
+        python manage.py cms generate_avro_schemas org.openedx.learning.course.enrollment.changed.v1
+
+        # multiple signals
+        python manage.py cms generate_avro_schemas org.openedx.learning.course.enrollment.changed.v1 /
+            org.openedx.learning.course.unenrollment.completed.v1
+
+        # all signals
+        python manage.py cms generate_avro_schemas -all
+
+    """
+
+    def add_arguments(self, parser):
+        """
+        Add arguments for either individual event types or all of them.
+        """
+        parser.add_argument(
+            'types',
+            nargs='*',
+            type=str,
+            help='Event types for which to write and save the schema, separated by a space'
+        )
+
+        parser.add_argument(
+            '--all',
+            action="store_true",
+            help='Write schema for all event types'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Create consumer based on django settings and consume events.
+        """
+        load_all_signals()
+        if options['all']:
+            signals = OpenEdxPublicSignal.all_events()
+        else:
+            signals = [OpenEdxPublicSignal.get_signal_by_type(event_type) for event_type in options['types']]
+
+        for signal in signals:
+            if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:
+                logger.info(f"Known unserializable signal: {signal.event_type}. Skipping.")
+                continue
+            serializer = AvroSignalSerializer(signal)
+            schema_dict = serializer.schema
+            filename = f"{signal.event_type.replace('.','+')}_schema.avsc"
+            root_path = import_module('openedx_events').__path__[0]
+            folder_path = f"{root_path}/event_bus/avro/tests/schemas"
+            full_file_name = f"{folder_path}/{filename}"
+            if os.path.exists(full_file_name):
+                confirmation = input(f"Warning: overwriting schema for {signal.event_type}. Are you sure you want to "
+                                     f"continue [y/n]? ")
+                if confirmation.lower().strip() != 'y':
+                    logger.info(f"Skipping generating schema for {signal.event_type}")
+                    continue
+            if not os.path.exists(folder_path):
+                os.makedirs(folder_path)
+            logger.info(f"Writing {full_file_name}")
+            with open(full_file_name, 'w') as writes:
+                writes.write(json.dumps(schema_dict, indent=2))

--- a/openedx_events/management/commands/generate_avro_schemas.py
+++ b/openedx_events/management/commands/generate_avro_schemas.py
@@ -23,7 +23,8 @@ class Command(BaseCommand):
     Generate and save the current Avro schemas of OpenEdxPublicSignals.
 
     Schemas will be saved in openedx_events/avro/tests/schemas. The folder will be created if it does not already exist.
-    Should only be used for new signals. Existing files will be overwritten, so use with caution.
+    Should only be used for new signals. Even if a schema is changing, it is recommended you leave the original
+    in place. Only overwrite the file for an exceptional case, like the schema still being under development.
 
     Example::
 
@@ -77,7 +78,8 @@ class Command(BaseCommand):
             folder_path = f"{root_path}/event_bus/avro/tests/schemas"
             full_file_name = f"{folder_path}/{filename}"
             if os.path.exists(full_file_name):
-                confirmation = input(f"Warning: overwriting schema for {signal.event_type}. Are you sure you want to "
+                confirmation = input(f"Warning: overwriting schema for {signal.event_type}. It is recommended to leave"
+                                     f" existing schemas unchanged. Are you sure you want to "
                                      f"continue [y/n]? ")
                 if confirmation.lower().strip() != 'y':
                     logger.info(f"Skipping generating schema for {signal.event_type}")

--- a/openedx_events/management/commands/generate_avro_schemas.py
+++ b/openedx_events/management/commands/generate_avro_schemas.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             org.openedx.learning.course.unenrollment.completed.v1
 
         # all signals
-        python manage.py cms generate_avro_schemas -all
+        python manage.py cms generate_avro_schemas --all
 
     """
 

--- a/openedx_events/tests/test_generate_avro_schemas.py
+++ b/openedx_events/tests/test_generate_avro_schemas.py
@@ -1,0 +1,87 @@
+"""Tests for generate_avro_schemas."""
+from importlib import import_module
+import os
+from unittest.mock import call, mock_open, patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from openedx_events.event_bus.avro.tests.test_utilities import create_simple_signal
+from openedx_events.management.commands.generate_avro_schemas import Command
+from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
+
+
+class TestGenerateAvroCommand(FreezeSignalCacheMixin, TestCase):
+    """
+    Tests for generate_avro_schemas management command.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.root_path = import_module('openedx_events').__path__[0]
+        cls.folder_path = f"{cls.root_path}/event_bus/avro/tests/schemas"
+
+    # assume the schema folder already exists but has no files so we're not overwriting anything
+    @patch('os.path.exists', lambda path: path == TestGenerateAvroCommand.folder_path)
+    def test_generate_multiple_specified_schemas(self):
+        signal_a = create_simple_signal({'key': str})
+        signal_b = create_simple_signal({'key': str}, event_type='simple.signal.B')
+        with patch("builtins.open", mock_open()) as mock_file:
+            call_command(Command(), signal_a.event_type, signal_b.event_type)
+            # make sure we created files with the correct name
+            mock_file.assert_has_calls([
+                    call(f"{TestGenerateAvroCommand.folder_path}/simple+signal_schema.avsc", "w"),
+                    call(f"{TestGenerateAvroCommand.folder_path}/simple+signal+B_schema.avsc", "w"),
+                ],
+                # need any_order=True because opening a file involves a bunch of other secret calls
+                any_order=True)
+            handle = mock_file()
+            # make sure we wrote the schemas. Exact JSON determined from testing
+            assert handle.write.mock_calls == [
+                call('{\n  "name": "CloudEvent",\n  "type": "record",\n'
+                     '  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",'
+                     '\n  "fields": [\n    {\n      "name": "key",\n      "type": "string"\n    }\n  ],\n  "namespace":'
+                     ' "simple.signal"\n}'),
+                call('{\n  "name": "CloudEvent",\n  "type": "record",\n'
+                     '  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",'
+                     '\n  "fields": [\n    {\n      "name": "key",\n      "type": "string"\n    }\n  ],\n  "namespace":'
+                     ' "simple.signal.B"\n}')
+            ]
+
+    # pretend that all files in the schema folder have already been created
+    @patch('os.path.exists', lambda path: TestGenerateAvroCommand.folder_path in path)
+    def test_command_warns_if_schema_exists(self):
+        signal_a = create_simple_signal({'key': str})
+        with patch("builtins.open", mock_open()) as mock_file:
+            # test we skip if the user doesn't want to continue
+            with patch("builtins.input", return_value='n'):
+                call_command(Command(), signal_a.event_type)
+                mock_file.assert_not_called()
+            # check we continue if the user wants to continue
+            with patch("builtins.input", return_value='Y'):
+                call_command(Command(), signal_a.event_type)
+                mock_file.assert_has_calls([
+                    call(f"{TestGenerateAvroCommand.folder_path}/simple+signal_schema.avsc", "w"),
+                ])
+
+    @patch('os.path.exists', lambda path: path == TestGenerateAvroCommand.folder_path)
+    def test_generate_all(self):
+        load_all_signals()
+        expected_files = [f"{TestGenerateAvroCommand.folder_path}/{signal.event_type.replace('.','+')}_schema.avsc"
+                          for signal in OpenEdxPublicSignal.all_events() if signal.event_type
+                          not in KNOWN_UNSERIALIZABLE_SIGNALS]
+        with patch("builtins.open", mock_open()) as mock_file:
+            call_command(Command(), all=True)
+            mock_file.assert_has_calls([call(file, 'w') for file in expected_files], any_order=True)
+
+    # mostly added to appease the coverage gods
+    @patch('os.makedirs')
+    def test_create_schema_dir_if_not_exists(self, mock_makedirs):
+        signal = create_simple_signal({"key": str})
+        old_exists = os.path.exists
+        with patch('os.path.exists',
+                   lambda path: False if path == TestGenerateAvroCommand.folder_path else old_exists(path)):
+            with patch("builtins.open", mock_open()):
+                call_command(Command(), signal.event_type)
+        mock_makedirs.assert_called_once_with(TestGenerateAvroCommand.folder_path)

--- a/openedx_events/tests/test_generate_avro_schemas.py
+++ b/openedx_events/tests/test_generate_avro_schemas.py
@@ -1,6 +1,6 @@
 """Tests for generate_avro_schemas."""
-from importlib import import_module
 import os
+from importlib import import_module
 from unittest.mock import call, mock_open, patch
 
 from django.core.management import call_command

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -15,6 +15,14 @@ from openedx_events.utils import format_responses
 
 log = getLogger(__name__)
 
+# If a signal is explicitly not for use with the event bus, add it to this list
+#  and document why in the event's annotations
+KNOWN_UNSERIALIZABLE_SIGNALS = [
+    "org.openedx.learning.discussions.configuration.changed.v1",
+    "org.openedx.content_authoring.course.certificate_config.changed.v1",
+    "org.openedx.content_authoring.course.certificate_config.deleted.v1",
+]
+
 
 class OpenEdxPublicSignal(Signal):
     """


### PR DESCRIPTION
**Description:**
Add unit tests to confirm that any schema updates are backward and forward compatible with stored versions. Also adds a management command to generate and store the current Avro schema for each signal.

Manual testing:
Test 1: Add required field "thing" to CourseEnrollmentData
`FAILED openedx_events/event_bus/avro/tests/test_avro.py::TestAvro::test_evolution_is_backward_compatible - fastavro._read_common.SchemaResolutionError: No default value for thing`

Test 2: Remove required field "creation_date" from CourseEnrollmentData
`FAILED openedx_events/event_bus/avro/tests/test_avro.py::TestAvro::test_evolution_is_forward_compatible - fastavro._read_common.SchemaResolutionError: No default value for creation_date`

Test 3: Change type of user_data from UserData to str in CourseEnrollmentData
`FAILED openedx_events/event_bus/avro/tests/test_avro.py::TestAvro::test_evolution_is_backward_compatible - fastavro._read_common.SchemaResolutionError: Schema mismatch: {'type': 'record', 'name': 'org.openedx.learning.course.enrollment.created.v1.UserData', 'fields': [{'name': 'id', 'ty...`
`FAILED openedx_events/event_bus/avro/tests/test_avro.py::TestAvro::test_evolution_is_forward_compatible - fastavro._read_common.SchemaResolutionError: Schema mismatch: string is not {'type': 'record', 'name': 'org.openedx.learning.course.enrollment.created.v1.UserData', 'fields': [{'na...`

Test 4: Add optional field thing to CourseEnrollmentData
All tests pass

Test 4: Remove optional field created_by from CourseEnrollmentData
All tests pass


**ISSUE:** https://github.com/edx/edx-arch-experiments/issues/271
**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.