### PR TITLE
fix: use correct subdomain in event_type of XBLOCK_SKILL_VERIFIED

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[8.0.1] - 2023-05-16
+--------------------
+Changed
+~~~~~~~
+* Fixed event_type of XBLOCK_SKILL_VERIFIED signal
+
 [8.0.0] - 2023-05-16
 --------------------
 Changed

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "8.0.0"
+__version__ = "8.0.1"

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -156,7 +156,7 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
 # .. event_description: Fired when an XBlock skill is verified.
 # .. event_data: XBlockSkillVerificationData
 XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
-    event_type="org.openedx.content_authoring.xblock.skill.verified.v1",
+    event_type="org.openedx.learning.xblock.skill.verified.v1",
     data={
         "xblock_info": XBlockSkillVerificationData,
     }


### PR DESCRIPTION
**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.