### PR TITLE
fix: update security contact email for the correct new one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ file in this repo.
 Reporting Security Issues
 *************************
 
-Please do not report security issues in public. Please email security@tcril.org.
+Please do not report security issues in public. Please email security@openedx.org.
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/openedx-events.svg
     :target: https://pypi.python.org/pypi/openedx-events/


### PR DESCRIPTION
**Description:** 
Inspired by [this PR](https://github.com/openedx/openedx-filters/pull/94/) opened in the openedx-filters repository. This PR relies on this https://github.com/openedx/wg-security/issues/15 to update the security email contact.
