### PR TITLE
docs: change docs link to edx-platform Hooks guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Getting Help
 Documentation
 =============
 
-See `documentation on Read the Docs <https://openedx-events.readthedocs.io/en/latest/>`_.
+See the `Open edX Hooks Extension Framework guide <https://github.com/openedx/edx-platform/blob/master/docs/guides/hooks/index.rst>`_ in edx-platform.
 
 More Help
 =========


### PR DESCRIPTION
The current link 404s, as this repo's docs are empty and unpublished.
