### PR TITLE
feat: create event for discussion events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ Changed
 ~~~~~~~
 * Re-licensed this repository from AGPL 3.0 to Apache 2.0
 
+[8.9.0] - 2023-10-04
+--------------------
+Added
+~~~~~
+* Added new ``FORUM_THREAD_CREATED``, ``FORUM_THREAD_RESPONSE_CREATED``, ``FORUM_RESPONSE_COMMENT_CREATED`` events in learning subdomain
+
 [8.8.0] - 2023-10-02
 --------------------
 Added

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -372,3 +372,56 @@ class ManageStudentsPermissionData:
     permission = attr.ib(type=str)
     course_key = attr.ib(type=str, default=None)
     org = attr.ib(type=str, default=None)
+
+
+@attr.s(frozen=True)
+class DiscussionThreadData:
+    """
+    Attributes defined for the Open edX to represent events in the Forum such as comments, responses, and threads.
+
+    For more details on the data attributes, please see the following documentation:
+    https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-forum-thread-created
+
+    Arguments:
+        anonymous (bool): indicates whether the user is anonymous.
+        anonymous_to_peers (bool): indicates whether the user is anonymous to peers.
+        body (str): body of the discussion thread.
+        category_id (int): identifier of the category.
+        category_name (str): name of the category.
+        commentable_id (str): identifier of the commentable.
+        group_id (int): identifier of the group.
+        id (int): identifier of the discussion thread.
+        team_id (int): identifier of the team.
+        thread_type (str): type of the thread.
+        title (str): title of the thread.
+        title_truncated (bool): indicates whether the title is truncated.
+        truncated (bool): indicates whether the thread is truncated.
+        url (str): url of the thread.
+        user (UserData): information of the user that authored the thread/comment/response.
+        course_id (CourseKey): identifier of the course.
+        discussion (dict): discussion data. (optional, specific to comments and responses)
+        user_course_roles (List[str]): user course roles.
+        user_forums_roles (List[str]): user forums roles.
+        options (dict): options for the thread.
+    """
+
+    anonymous = attr.ib(type=bool)
+    anonymous_to_peers = attr.ib(type=bool)
+    body = attr.ib(type=str)
+    category_id = attr.ib(type=int)
+    category_name = attr.ib(type=str)
+    commentable_id = attr.ib(type=str)
+    group_id = attr.ib(type=int)
+    id = attr.ib(type=int)
+    team_id = attr.ib(type=int)
+    thread_type = attr.ib(type=str)
+    title = attr.ib(type=str)
+    title_truncated = attr.ib(type=bool)
+    truncated = attr.ib(type=bool)
+    url = attr.ib(type=str)
+    user = attr.ib(type=UserData)
+    course_id = attr.ib(type=CourseKey)
+    discussion = attr.ib(type=dict, factory=dict)
+    user_course_roles = attr.ib(type=List[str], factory=list)
+    user_forums_roles = attr.ib(type=List[str], factory=list)
+    options = attr.ib(type=dict, factory=dict)

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -13,6 +13,7 @@ from openedx_events.learning.data import (
     CohortData,
     CourseDiscussionConfigurationData,
     CourseEnrollmentData,
+    DiscussionThreadData,
     ExamAttemptData,
     ManageStudentsPermissionData,
     PersistentCourseGradeData,
@@ -273,5 +274,41 @@ MANAGE_STUDENTS_PERMISSION_REMOVED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.user.manage.students.permission.removed.v1",
     data={
         "course_staff_data": ManageStudentsPermissionData,
+    }
+)
+
+# .. event_type: org.openedx.learning.forum.thread.created.v1
+# .. event_name: FORUM_THREAD_CREATED
+# .. event_description: Emitted when a new thread is created in a discussion
+# .. event_data: DiscussionThreadData
+#       Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+FORUM_THREAD_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.thread.created.v1",
+    data={
+        "thread": DiscussionThreadData,
+    }
+)
+
+# .. event_type: org.openedx.learning.forum.thread.response.created.v1
+# .. event_name: FORUM_THREAD_RESPONSE_CREATED
+# .. event_description: Emitted when a new response is added to a thread
+# .. event_data: DiscussionThreadData
+#        Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+FORUM_THREAD_RESPONSE_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.response.created.v1",
+    data={
+        "thread": DiscussionThreadData,
+    }
+)
+
+# .. event_type: org.openedx.learning.forum.thread.response.comment.created.v1
+# .. event_name: FORUM_RESPONSE_COMMENT_CREATED
+# .. event_description: Emitted when a new comment is added to a response
+# .. event_data: DiscussionThreadData
+#       Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+FORUM_RESPONSE_COMMENT_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.response.created.v1",
+    data={
+        "thread": DiscussionThreadData,
     }
 )

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -21,7 +21,10 @@ KNOWN_UNSERIALIZABLE_SIGNALS = [
     "org.openedx.learning.discussions.configuration.changed.v1",
     "org.openedx.content_authoring.course.certificate_config.changed.v1",
     "org.openedx.content_authoring.course.certificate_config.deleted.v1",
-    "org.openedx.learning.user.notification.requested.v1"
+    "org.openedx.learning.user.notification.requested.v1",
+    "org.openedx.learning.thread.created.v1",
+    "org.openedx.learning.response.created.v1",
+    "org.openedx.learning.comment.created.v1",
 ]
 
 


### PR DESCRIPTION
**Description:** This PR creates signals for events related to forum threads and comments

Extracted from: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-forum-thread-created

This PR is the base for https://github.com/openedx/edx-platform/pull/33374