### PR TITLE
feat: add event for course wide notification request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[9.2.0] - 2023-11-16
+--------------------
+Added
+~~~~~~~
+* Added new COURSE_NOTIFICATION_REQUESTED event in learning
+
 [9.1.0] - 2023-11-07
 --------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.1.0"
+__version__ = "9.2.0"

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -243,12 +243,12 @@ class UserNotificationData:
     Attributes defined for Open edX User Notification data object.
 
     Arguments:
-        user_ids (List(int)): identifier of the user to which the notification belongs.
+        user_ids (List(int)): identifier of the users to which the notification belongs.
         notification_type (str): type of the notification.
-        context (dict): additional structured information about the context in
-                        which this topic is used, such as the section, subsection etc.
         content_url (str): url of the content.
         app_name (str): name of the app.
+        course_key (str): identifier of the Course object.
+        context (dict): additional structured information about the context of the notification.
     """
 
     user_ids = attr.ib(type=List[int])
@@ -425,3 +425,47 @@ class DiscussionThreadData:
     user_course_roles = attr.ib(type=List[str], factory=list)
     user_forums_roles = attr.ib(type=List[str], factory=list)
     options = attr.ib(type=dict, factory=dict)
+
+
+@attr.s(frozen=True)
+class CourseNotificationData:
+    """
+    Attributes defined for Open edX Course Notification data object.
+
+    Arguments:
+        course_key (str): identifier of the Course object.
+        app_name (str): name of the app requesting the course notification.
+        notification_type (str): type of the notification.
+        content_url (str): url of the content the notification will redirect to.
+        content_context (dict): additional information related to the content of the notification.
+            Notification content templates are defined in edx-platform here:
+                https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/notifications/base_notification.py#L10
+
+        Example of content_context for a discussion notification (new_comment_on_response):
+
+            {
+                ...,
+                "content_context": {
+                    "post_title": "Post Title",
+                    "replier_name": "test_user",
+            }
+
+        audience_filters (dict): additional information related to the audience of the notification.
+            We can have different filters on course level, such as roles, enrollments, cohorts etc.
+
+        Example of audience_filters for a discussion notification (new_discussion_post):
+
+            {
+                ...,
+                "audience_filters": {
+                    "enrollment": ["verified", "audit"],
+                    "role": ["discussion admin", "discussion moderator"],
+            }
+    """
+
+    course_key = attr.ib(type=CourseKey)
+    app_name = attr.ib(type=str)
+    notification_type = attr.ib(type=str)
+    content_url = attr.ib(type=str)
+    content_context = attr.ib(type=dict, factory=dict)
+    audience_filters = attr.ib(type=dict, factory=dict)

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -13,6 +13,7 @@ from openedx_events.learning.data import (
     CohortData,
     CourseDiscussionConfigurationData,
     CourseEnrollmentData,
+    CourseNotificationData,
     DiscussionThreadData,
     ExamAttemptData,
     ManageStudentsPermissionData,
@@ -188,7 +189,7 @@ XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
 )
 
 # .. event_type: org.openedx.learning.user.notification.requested.v1
-# .. event_name: USER_NOTIFICATION
+# .. event_name: USER_NOTIFICATION_REQUESTED
 # .. event_description: Can be fired from apps to send user notifications.
 # .. event_data: UserNotificationSendListData
 # Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
@@ -310,5 +311,19 @@ FORUM_RESPONSE_COMMENT_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.response.created.v1",
     data={
         "thread": DiscussionThreadData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.course.notification.requested.v1
+# .. event_name: COURSE_NOTIFICATION_REQUESTED
+# .. event_description: Emitted when a notification is requested for a course
+# .. event_data: CourseNotificationData
+# Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+#
+COURSE_NOTIFICATION_REQUESTED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.notification.requested.v1",
+    data={
+        "course_notification_data": CourseNotificationData,
     }
 )

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -25,6 +25,7 @@ KNOWN_UNSERIALIZABLE_SIGNALS = [
     "org.openedx.learning.thread.created.v1",
     "org.openedx.learning.response.created.v1",
     "org.openedx.learning.comment.created.v1",
+    "org.openedx.learning.course.notification.requested.v1",
 ]
 
 


### PR DESCRIPTION
**Description:** This PR adds the `COURSE_NOTIFICATION_REQUESTED` event, that will be emitted whenever there is a request for a notification to be sent to all learners within a course.

The event will be emitted whenever there is a request for a notification to be sent out to a course-wide audience. The event has the `course_key` param identifying the course, and also provides the `audience_filter` param to specify subset of users within a course that the notification should be sent out to. Example of scenarios where this event could be used:

- Send out course updates to all verified learners,
- New Discussion post created in forums for course to be sent to all enrolled learner/ cohorted learners etc.

The event also contains fields like `app_name`, `notification_type`, `content_context` and `content_url` that contain information about the notification, and it's content. 

The [notification app](https://github.com/openedx/edx-platform/tree/master/openedx/core/djangoapps/notifications) in `edx-platform` will listen to this event, and process the notification request for course-wide notifications, delivering the notification to appropriate audience (PR to be created on `edx-platform` once this gets merged, and event becomes available).

Other 

**ISSUE:** https://2u-internal.atlassian.net/browse/INF-1134


**Reviewers:**
- [x] tag reviewer
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
