### PR TITLE
feat: use new setting to set ce_source

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 --------------------
 Changed
 ~~~~~~~
-* Choose new EVENT_BUS_APP_NAME setting over SERVICE_VARIANT for data source
+* Allow new EVENT_BUS_APP_NAME setting to override SERVICE_VARIANT for data source.
 
 [9.2.0] - 2023-11-16
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 --------------------
 Changed
 ~~~~~~~
-* Allow new EVENTs_SERVICE_NAME setting to override SERVICE_VARIANT for data source.
+* Allow new EVENTS_SERVICE_NAME setting to override SERVICE_VARIANT for data source.
 
 [9.2.0] - 2023-11-16
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Unreleased
 --------------------
 Changed
 ~~~~~~~
-* Allow new EVENT_BUS_APP_NAME setting to override SERVICE_VARIANT for data source.
+* Allow new EVENTs_SERVICE_NAME setting to override SERVICE_VARIANT for data source.
 
 [9.2.0] - 2023-11-16
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+[9.3.0] - 2024-01-24
+--------------------
+Changed
+~~~~~~~
+* Choose new EVENT_BUS_APP_NAME setting over SERVICE_VARIANT for data source
+
 [9.2.0] - 2023-11-16
 --------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.2.0"
+__version__ = "9.3.0"

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -29,26 +29,23 @@ def _ensure_utc_time(_, attribute, value):
 
 def get_service_name():
     """
-    Get the service name that should be used in the source of an event.
+    Get the service name of the producing/consuming service of an event (or None if not set).
     """
     # .. setting_name: EVENTS_SERVICE_NAME
     # .. setting_default: None
-    # .. setting_description: Identifier for the producing/consuming service of an event. Used in setting the source in
-    #   the EventsMetadata. If not set, the EventsMetadata object will look for a SERVICE_VARIANT setting (usually only
-    #   set for lms and cms). The full source will be set to openedx/<EVENTS_SERVICE_NAME or SERVICE_VARIANT>/web.
-    #   If neither variable is set, the source will be "SERVICE_NAME_UNSET"
+    # .. setting_description: Identifier for the producing/consuming service of an event. For example, "cms" or
+    #   "course-discovery." Used, among other places, to determine the source header of the event.
     return getattr(settings, "EVENTS_SERVICE_NAME", None) or getattr(settings, "SERVICE_VARIANT", None)
 
 
 def _get_source():
     """
-    Get the source for an event.
+    Get the source for an event using the service name.
+
+    If the service name is set, the full source will be set to openedx/<service_name>/web or
+    openedx/SERVICE_NAME_UNSET/web if service name is None.
     """
-    service_name = get_service_name()
-    if service_name:
-        return "openedx/{service}/web".format(service=service_name)
-    else:
-        return "SERVICE_NAME_UNSET"
+    return "openedx/{service}/web".format(service=(get_service_name() or "SERVICE_NAME_UNSET"))
 
 
 @attr.s(frozen=True)

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -27,7 +27,7 @@ def _ensure_utc_time(_, attribute, value):
     raise ValueError(f"'{attribute.name}' must have timezone.utc")
 
 
-def get_source_name():
+def get_service_name():
     """
     Get the value that should be used for the source of an event.
     """
@@ -36,7 +36,7 @@ def get_source_name():
     # .. setting_description: Identifier for the producing/consuming service of an event. Used in setting the source in
     #   the EventsMetadata. If not set, the EventsMetadata object will look for a SERVICE_VARIANT setting (usually only
     #   set for lms and cms). The full source will be set to openedx/<EVENTS_SERVICE_NAME or SERVICE_VARIANT>/web.
-    #   If neither variable is set, the source will be "unidentified."
+    #   If neither variable is set, the source will be "SERVICE_NAME_UNSET"
     return getattr(settings, "EVENTS_SERVICE_NAME", None) or getattr(settings, "SERVICE_VARIANT", None)
 
 
@@ -75,9 +75,7 @@ class EventsMetadata:
     source = attr.ib(
         type=str, default=None,
         converter=attr.converters.default_if_none(
-            attr.Factory(lambda: "openedx/{service}/web".format(service=get_source_name()) if get_source_name()
-                         else "unidentified")
-        ),
+            attr.Factory(lambda: "openedx/{service}/web".format(service=(get_service_name() or "SERVICE_NAME_UNSET")))),
         validator=attr.validators.instance_of(str),
     )
     sourcehost = attr.ib(

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -29,7 +29,7 @@ def _ensure_utc_time(_, attribute, value):
 
 def get_service_name():
     """
-    Get the value that should be used for the source of an event.
+    Get the service name that should be used in the source of an event.
     """
     # .. setting_name: EVENTS_SERVICE_NAME
     # .. setting_default: None
@@ -41,6 +41,9 @@ def get_service_name():
 
 
 def _get_source():
+    """
+    Get the source for an event.
+    """
     service_name = get_service_name()
     if service_name:
         return "openedx/{service}/web".format(service=service_name)

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -39,6 +39,13 @@ def get_service_name():
     #   If neither variable is set, the source will be "SERVICE_NAME_UNSET"
     return getattr(settings, "EVENTS_SERVICE_NAME", None) or getattr(settings, "SERVICE_VARIANT", None)
 
+def _get_source():
+    service_name = get_service_name()
+    if service_name:
+        return "openedx/{service}/web".format(service=service_name)
+    else:
+        return "SERVICE_NAME_UNSET"
+
 
 @attr.s(frozen=True)
 class EventsMetadata:
@@ -74,8 +81,7 @@ class EventsMetadata:
     )
     source = attr.ib(
         type=str, default=None,
-        converter=attr.converters.default_if_none(
-            attr.Factory(lambda: "openedx/{service}/web".format(service=(get_service_name() or "SERVICE_NAME_UNSET")))),
+        converter=attr.converters.default_if_none(attr.Factory(_get_source)),
         validator=attr.validators.instance_of(str),
     )
     sourcehost = attr.ib(

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -26,7 +26,11 @@ def _ensure_utc_time(_, attribute, value):
         return
     raise ValueError(f"'{attribute.name}' must have timezone.utc")
 
+
 def get_source_name():
+    """
+    Get the value that should be used for the source of an event.
+    """
     source = getattr(settings, "EVENT_BUS_APP_NAME", None)
     if not source:
         source = getattr(settings, "SERVICE_VARIANT", None)

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -39,6 +39,7 @@ def get_service_name():
     #   If neither variable is set, the source will be "SERVICE_NAME_UNSET"
     return getattr(settings, "EVENTS_SERVICE_NAME", None) or getattr(settings, "SERVICE_VARIANT", None)
 
+
 def _get_source():
     service_name = get_service_name()
     if service_name:

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -31,10 +31,13 @@ def get_source_name():
     """
     Get the value that should be used for the source of an event.
     """
-    source = getattr(settings, "EVENT_BUS_SERVICE_NAME", None)
-    if not source:
-        source = getattr(settings, "SERVICE_VARIANT", None)
-    return source or ""
+    # .. setting_name: EVENTS_SERVICE_NAME
+    # .. setting_default: None
+    # .. setting_description: Identifier for the producing/consuming service of an event. Used in setting the source in
+    #   the EventsMetadata. If not set, the EventsMetadata object will look for a SERVICE_VARIANT setting (usually only
+    #   set for lms and cms). The full source will be set to openedx/<EVENTS_SERVICE_NAME or SERVICE_VARIANT>/web.
+    #   If neither variable is set, the source will be "unidentified."
+    return getattr(settings, "EVENTS_SERVICE_NAME", None) or getattr(settings, "SERVICE_VARIANT", None)
 
 
 @attr.s(frozen=True)
@@ -72,7 +75,8 @@ class EventsMetadata:
     source = attr.ib(
         type=str, default=None,
         converter=attr.converters.default_if_none(
-            attr.Factory(lambda: "openedx/{service}/web".format(service=get_source_name()))
+            attr.Factory(lambda: "openedx/{service}/web".format(service=get_source_name()) if get_source_name()
+                         else "unidentified")
         ),
         validator=attr.validators.instance_of(str),
     )

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -30,6 +30,8 @@ def _ensure_utc_time(_, attribute, value):
 def get_service_name():
     """
     Get the service name of the producing/consuming service of an event (or None if not set).
+
+    Uses EVENTS_SERVICE_NAME setting if present, otherwise looks for SERVICE_VARIANT.
     """
     # .. setting_name: EVENTS_SERVICE_NAME
     # .. setting_default: None

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -29,7 +29,7 @@ def _ensure_utc_time(_, attribute, value):
 def get_source_name():
     source = getattr(settings, "EVENT_BUS_APP_NAME", None)
     if not source:
-        source = getattr(settings, "SERVICE_VARIANT")
+        source = getattr(settings, "SERVICE_VARIANT", None)
     return source or ""
 
 

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -26,6 +26,12 @@ def _ensure_utc_time(_, attribute, value):
         return
     raise ValueError(f"'{attribute.name}' must have timezone.utc")
 
+def get_source_name():
+    source = getattr(settings, "EVENT_BUS_APP_NAME", None)
+    if not source:
+        source = getattr(settings, "SERVICE_VARIANT")
+    return source or ""
+
 
 @attr.s(frozen=True)
 class EventsMetadata:
@@ -62,7 +68,7 @@ class EventsMetadata:
     source = attr.ib(
         type=str, default=None,
         converter=attr.converters.default_if_none(
-            attr.Factory(lambda: "openedx/{service}/web".format(service=getattr(settings, "SERVICE_VARIANT", "")))
+            attr.Factory(lambda: "openedx/{service}/web".format(service=get_source_name()))
         ),
         validator=attr.validators.instance_of(str),
     )

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -31,7 +31,7 @@ def get_source_name():
     """
     Get the value that should be used for the source of an event.
     """
-    source = getattr(settings, "EVENT_BUS_APP_NAME", None)
+    source = getattr(settings, "EVENT_BUS_SERVICE_NAME", None)
     if not source:
         source = getattr(settings, "SERVICE_VARIANT", None)
     return source or ""

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -33,7 +33,7 @@ class TestEventsMetadata(TestCase):
     @ddt.data(
         ('settings_variant', None, 'openedx/settings_variant/web'),
         (None, 'my_service', 'openedx/my_service/web'),
-        (None, None, 'unidentified'),
+        (None, None, 'SERVICE_NAME_UNSET'),
         ('settings_variant', 'my_service', 'openedx/my_service/web')
     )
     @ddt.unpack

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -33,14 +33,14 @@ class TestEventsMetadata(TestCase):
     @ddt.data(
         ('settings_variant', None, 'openedx/settings_variant/web'),
         (None, 'my_service', 'openedx/my_service/web'),
-        (None, None, 'openedx//web'),
+        (None, None, 'unidentified'),
         ('settings_variant', 'my_service', 'openedx/my_service/web')
     )
     @ddt.unpack
     def test_events_metadata_source(self, settings_variant, event_bus_service_name, expected_source):
         with override_settings(
                 SERVICE_VARIANT=settings_variant,
-                EVENT_BUS_SERVICE_NAME=event_bus_service_name,
+                EVENTS_SERVICE_NAME=event_bus_service_name,
         ):
             metadata = EventsMetadata(
                 event_type='test_type'

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -39,7 +39,7 @@ class TestEventsMetadata(TestCase):
     @ddt.unpack
     def test_events_metadata_source(self, settings_variant, event_bus_app_name, expected_source):
         with override_settings(
-                SETTINGS_VARIANT=settings_variant,
+                SERVICE_VARIANT=settings_variant,
                 EVENT_BUS_APP_NAME=event_bus_app_name,
         ):
             metadata = EventsMetadata(

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -32,15 +32,15 @@ class TestEventsMetadata(TestCase):
 
     @ddt.data(
         ('settings_variant', None, 'openedx/settings_variant/web'),
-        (None, 'eb_app_name', 'openedx/eb_app_name/web'),
+        (None, 'my_service', 'openedx/my_service/web'),
         (None, None, 'openedx//web'),
-        ('settings_variant', 'eb_app_name', 'openedx/eb_app_name/web')
+        ('settings_variant', 'my_service', 'openedx/my_service/web')
     )
     @ddt.unpack
-    def test_events_metadata_source(self, settings_variant, event_bus_app_name, expected_source):
+    def test_events_metadata_source(self, settings_variant, event_bus_service_name, expected_source):
         with override_settings(
                 SERVICE_VARIANT=settings_variant,
-                EVENT_BUS_APP_NAME=event_bus_app_name,
+                EVENT_BUS_APP_NAME=event_bus_service_name,
         ):
             metadata = EventsMetadata(
                 event_type='test_type'

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -33,7 +33,7 @@ class TestEventsMetadata(TestCase):
     @ddt.data(
         ('settings_variant', None, 'openedx/settings_variant/web'),
         (None, 'my_service', 'openedx/my_service/web'),
-        (None, None, 'SERVICE_NAME_UNSET'),
+        (None, None, 'openedx/SERVICE_NAME_UNSET/web'),
         ('settings_variant', 'my_service', 'openedx/my_service/web')
     )
     @ddt.unpack

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -36,6 +36,7 @@ class TestEventsMetadata(TestCase):
         (None, None, 'openedx//web'),
         ('settings_variant', 'eb_app_name', 'openedx/eb_app_name/web')
     )
+    @ddt.unpack
     def test_events_metadata_source(self, settings_variant, event_bus_app_name, expected_source):
         with override_settings(
                 SETTINGS_VARIANT=settings_variant,

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -40,7 +40,7 @@ class TestEventsMetadata(TestCase):
     def test_events_metadata_source(self, settings_variant, event_bus_service_name, expected_source):
         with override_settings(
                 SERVICE_VARIANT=settings_variant,
-                EVENT_BUS_APP_NAME=event_bus_service_name,
+                EVENT_BUS_SERVICE_NAME=event_bus_service_name,
         ):
             metadata = EventsMetadata(
                 event_type='test_type'

--- a/openedx_events/tests/test_data.py
+++ b/openedx_events/tests/test_data.py
@@ -46,4 +46,3 @@ class TestEventsMetadata(TestCase):
                 event_type='test_type'
             )
             self.assertEqual(metadata.source, expected_source)
-


### PR DESCRIPTION
**Description:** Use a new EVENTS_SERVICE_NAME setting to determine the source in EventsMetadata. Defaults to the old SERVICE_VARIANT setting if not set. SERVICE_VARIANT is usually only set on lms or cms, and has other uses, so it makes sense to have a new variable that all services can use for the events.

I didn't talk about how the EVENTS_SERVICE_NAME will be used to set the client id because that is Kafka specific.

**Testing instructions:**
pip install -e openedx-events
set EVENTS_SERVICE_NAME in your service settings
fire an event
check that the event source is openedx/<EVENTS_SERVICE_NAME>/web

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
