### PR TITLE
build: remove sphinx-book-theme constraint to use latest release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,8 +64,6 @@ html_theme_options = {
     "repository_url": "https://github.com/openedx/openedx-events",
     "repository_branch": "main",
     "path_to_docs": "docs/",
-    "logo_only": True,
-    "home_page_in_toc": True,
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,
@@ -83,7 +81,7 @@ html_theme_options = {
                 href="https://openedx.org"
                 property="cc:attributionName"
                 rel="cc:attributionURL"
-            >Axim Collaborative, Inc</a>
+            >Axim Collaborative</a>
         are licensed under a
             <a
                 rel="license"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,9 +9,6 @@
 # linking to it here is good.
 -c common_constraints.txt
 
-# Latest previous version has issues with doc8 because of conflicting docutils constraints
-sphinx-book-theme==0.4.0rc1
-
 # Temporary solution since this version raises RecursionError for test_generate_avro_schemas.py
 # This should be removed once the issue is fixed with a new astroid release or with a test_generate_avro_schemas.py
 # module refactor.

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 asgiref==3.7.2
@@ -13,7 +15,9 @@ asgiref==3.7.2
 attrs==23.2.0
     # via -r requirements/test.txt
 babel==2.14.0
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 build==1.0.3
@@ -126,10 +130,11 @@ pluggy==1.4.0
     #   pytest
 pycparser==2.21
     # via cffi
-pydata-sphinx-theme==0.12.0
+pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.17.2
     # via
+    #   accessible-pygments
     #   doc8
     #   pydata-sphinx-theme
     #   readme-renderer
@@ -163,7 +168,6 @@ pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-    #   sphinx-book-theme
 readme-renderer==42.0
     # via twine
 requests==2.31.0
@@ -187,7 +191,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==6.2.1
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
@@ -197,10 +201,8 @@ sphinx==5.3.0
     #   sphinxcontrib-contentui
 sphinx-autobuild==2021.3.14
     # via -r requirements/doc.in
-sphinx-book-theme==0.4.0rc1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.in
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinx-copybutton==0.5.2
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
@@ -250,6 +252,7 @@ typing-extensions==4.9.0
     #   -r requirements/test.txt
     #   asgiref
     #   edx-opaque-keys
+    #   pydata-sphinx-theme
     #   rich
 urllib3==2.1.0
     # via


### PR DESCRIPTION
### Description
This PR removes the existing `sphinx-book-theme` to use the latest release. Here's the comment we realized we need to utilize the constraint: https://github.com/openedx/openedx-events/pull/169#discussion_r1073980224
Also, we updated the theme configurations for the latest suggested on the open edx docs: https://docs.openedx.org/en/latest/developers/how-tos/add-sphinx-docs-to-a-repo.html. 