### PR TITLE
feat: add courseaccessrole events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ----------
+[9.4.0] - 2024-01-29
+--------------------
+Added
+~~~~~
+* Added new ``COURSE_ACCESS_ROLE_ADDED`` and ``COURSE_ACCESS_ROLE_REMOVED`` events in learning
 
 [9.3.0] - 2024-01-24
 --------------------

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.3.0"
+__version__ = "9.4.0"

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+user+course_access_role+added+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+user+course_access_role+added+v1_schema.avsc
@@ -1,0 +1,67 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "course_access_role_data",
+      "type": {
+        "name": "CourseAccessRoleData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "org_key",
+            "type": "string"
+          },
+          {
+            "name": "course_key",
+            "type": "string"
+          },
+          {
+            "name": "role",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.user.course_access_role.added.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+user+course_access_role+removed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+user+course_access_role+removed+v1_schema.avsc
@@ -1,0 +1,67 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "course_access_role_data",
+      "type": {
+        "name": "CourseAccessRoleData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "org_key",
+            "type": "string"
+          },
+          {
+            "name": "course_key",
+            "type": "string"
+          },
+          {
+            "name": "role",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.user.course_access_role.removed.v1"
+}

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -332,6 +332,24 @@ class ExamAttemptData:
 
 
 @attr.s(frozen=True)
+class CourseAccessRoleData:
+    """
+    Attributes defined for the Open edX Course Access Role data object.
+
+    Arguments:
+        user (UserData): user associated with the CourseAccessRole.
+        course_key (CourseKey): identifer of the related course object.
+        org (str): identifier of the organization.
+        role (str): the role of the user in the course.
+    """
+
+    user = attr.ib(type=UserData)
+    org_key = attr.ib(type=str)
+    course_key = attr.ib(type=CourseKey)
+    role = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
 class ManageStudentsPermissionData:
     """
     Attributes defined for the Open edX to represent users that can manage students within a course/org.

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -11,6 +11,7 @@ docs/decisions/0003-events-payload.rst
 from openedx_events.learning.data import (
     CertificateData,
     CohortData,
+    CourseAccessRoleData,
     CourseDiscussionConfigurationData,
     CourseEnrollmentData,
     CourseNotificationData,
@@ -253,6 +254,28 @@ EXAM_ATTEMPT_RESET = OpenEdxPublicSignal(
     event_type="org.openedx.learning.exam.attempt.reset.v1",
     data={
         "exam_attempt": ExamAttemptData,
+    }
+)
+
+# .. event_type: org.openedx.learning.user.course_access_role.added.v1
+# .. event_name: COURSE_ACCESS_ROLE_ADDED
+# .. event_description: Emitted when a user is given a course access role.
+# .. event_data: CourseAccessRoleData
+COURSE_ACCESS_ROLE_ADDED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.user.course_access_role.added.v1",
+    data={
+        "course_access_role_data": CourseAccessRoleData,
+    }
+)
+
+# .. event_type: org.openedx.learning.user.course_access_role.removed.v1
+# .. event_name: COURSE_ACCESS_ROLE_REMOVED
+# .. event_description: Emitted when a course access role is removed from a user.
+# .. event_data: CourseAccessRoleData
+COURSE_ACCESS_ROLE_REMOVED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.user.course_access_role.removed.v1",
+    data={
+        "course_access_role_data": CourseAccessRoleData,
     }
 )
 


### PR DESCRIPTION
**Description:** Creates new data class and events for publishing information about the creation or removal of an LMS [CourseAccessRole](https://github.com/openedx/edx-platform/blob/96b360a1ee9c756b6bd1032dc282bdb24d3f152c/common/djangoapps/student/models/user.py#L1044). We are not planning to account for the [roles and permissions changes](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3824648277/RBAC+Tech+Spec) at this point, events would be based on how roles currently work.

This will be consumed by [edx-exams](https://github.com/edx/edx-exams) to sync access to instructor tools and actions on the API.


**Author concerns:** These events will be used instead those added by https://github.com/openedx/openedx-events/pull/267. I plan to remove those in a separate PR since there is no plan to use those event definitions or supporting data classes.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

