### PR TITLE
fix: avoid infinite recursion of openedx-event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 ----------
+
+[9.5.1] - 2024-02-12
+--------------------
+Changed
+~~~~~~~
+* Fixed recursion error when consuming events on the same service that produced them.
+
 [9.5.0] - 2024-02-07
 --------------------
 Added

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.5.0"
+__version__ = "9.5.1"

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -179,6 +179,7 @@ class OpenEdxPublicSignalTestCache(FreezeSignalCacheMixin, TestCase):
             sender=None,
             user=self.user_mock,
             metadata=expected_metadata,
+            from_event_bus=False,
         )
 
     @patch("openedx_events.tooling.OpenEdxPublicSignal.generate_signal_metadata")
@@ -198,7 +199,8 @@ class OpenEdxPublicSignalTestCache(FreezeSignalCacheMixin, TestCase):
             self.public_signal.send_event(user=self.user_mock)
 
         self.ok_receiver.assert_called_once_with(
-            signal=self.public_signal, sender=None, user=self.user_mock, metadata=expected_metadata
+            signal=self.public_signal, sender=None, user=self.user_mock, metadata=expected_metadata,
+            from_event_bus=False
         )
         # format_responses is mocked out because its output is
         # complicated enough to warrant its own set of tests.
@@ -253,7 +255,7 @@ class OpenEdxPublicSignalTestCache(FreezeSignalCacheMixin, TestCase):
 
         assert response == expected_response
         mock_send_event_with_metadata.assert_called_once_with(
-            metadata=metadata, send_robust=True, foo="bar",
+            metadata=metadata, send_robust=True, foo="bar", from_event_bus=True
         )
 
     @ddt.data(


### PR DESCRIPTION
**Description:** This PR adds a new argument `from_event_bus` to the `send_event` method (and related ones) that allows marking a Django signal as already processed from the event bus and avoids infinite emission of the same signal if such signal is consumed in the same runtime.

The following code block must be used on the consumer to avoid processing the signal in the same process that emitted the signal:

```python
from openedx_events.tooling import SIGNAL_PROCESSED_FROM_EVENT_BUS

...

def my_signal(...):
    if not kwargs.get(SIGNAL_PROCESSED_FROM_EVENT_BUS, False):
        logger.info("Event received from a non-event bus backend, skipping...")
        return
```

This has been tested with the `event-bus-redis` without any changes as the behavior of calling `send_event_with_custom_metadata` is to enable the `from_event_bus` param. Tested on https://github.com/openedx/event-routing-backends/pull/361 with the signal emitted on https://github.com/openedx/event-tracking/pull/246

**ISSUE:** Solves: https://github.com/openedx/openedx-events/issues/79

**Testing instructions:**

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
