### PR TITLE
feat: Add autodoc for event annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: clean clean_tox compile_translations coverage diff_cover docs dummy_translations \
-        extract_translations fake_translations help pii_check pull_translations push_translations \
+        extract_translations fake_translations help pull_translations push_translations \
         quality requirements selfcheck test test-all upgrade validate install_transifex_client
 
 .DEFAULT_GOAL := help
@@ -56,9 +56,6 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality
 
-pii_check: ## check for PII annotations on all Django models
-	tox -e pii_check
-
 piptools: ## install pinned version of pip-compile and pip-sync
 	pip install -r requirements/pip.txt
 	pip install -r requirements/pip-tools.txt
@@ -72,11 +69,11 @@ test: clean ## run tests in the current virtualenv
 diff_cover: test ## find diff lines that need test coverage
 	diff-cover coverage.xml
 
-test-all: quality pii_check ## run tests on every supported Python/Django combination
+test-all: quality ## run tests on every supported Python/Django combination
 	tox
 	tox -e docs
 
-validate: quality pii_check test ## run tests and quality checks
+validate: quality test ## run tests and quality checks
 
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx_copybutton',
     'sphinx.ext.graphviz',
     'sphinxcontrib.mermaid',
+    'code_annotations.contrib.sphinx.extensions.openedx_events',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -1,0 +1,9 @@
+Events
+======
+
+This is the list of Open edX events found in this repository.
+
+.. note::
+    Events can be create in other projects and plugins as well, but these default events are guaranteed to exist.
+
+.. openedxevents::

--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -4,6 +4,6 @@ Events
 This is the list of Open edX events found in this repository.
 
 .. note::
-    Events can be create in other projects and plugins as well, but these default events are guaranteed to exist.
+    Events can be created in other projects and plugins as well, but these default events are guaranteed to exist.
 
 .. openedxevents::

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -5,5 +5,6 @@ References
    :maxdepth: 1
    :caption: Contents:
 
+   events
    oeps
    architecture-subdomains

--- a/openedx_events/analytics/signals.py
+++ b/openedx_events/analytics/signals.py
@@ -13,6 +13,7 @@ from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.analytics.tracking.event.emitted.v1
 # .. event_name: TRACKING_EVENT_EMITTED
+# .. event_key_field: tracking_log.name
 # .. event_description: emitted when a tracking log is created.
 # .. event_data: TrackingLogData
 TRACKING_EVENT_EMITTED = OpenEdxPublicSignal(

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -31,6 +31,7 @@ COURSE_CATALOG_INFO_CHANGED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.xblock.created.v1
 # .. event_name: XBLOCK_CREATED
+# .. event_key_field: xblock_info.usage_key
 # .. event_description: Fired when an XBlock is created.
 # .. event_data: XBlockData
 XBLOCK_CREATED = OpenEdxPublicSignal(
@@ -42,6 +43,7 @@ XBLOCK_CREATED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.xblock.updated.v1
 # .. event_name: XBLOCK_UPDATED
+# .. event_key_field: xblock_info.usage_key
 # .. event_description: Fired when an XBlock is updated.
 # .. event_data: XBlockData
 XBLOCK_UPDATED = OpenEdxPublicSignal(
@@ -53,6 +55,7 @@ XBLOCK_UPDATED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.xblock.published.v1
 # .. event_name: XBLOCK_PUBLISHED
+# .. event_key_field: xblock_info.usage_key
 # .. event_description: Fired when an XBlock is published. If a parent block
 #       with changes in one or more child blocks is published, only a single
 #       XBLOCK_PUBLISHED event is fired with parent block details.
@@ -70,6 +73,7 @@ XBLOCK_PUBLISHED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.xblock.deleted.v1
 # .. event_name: XBLOCK_DELETED
+# .. event_key_field: xblock_info.usage_key
 # .. event_description: Fired when an XBlock is deleted.
 # .. event_data: XBlockData
 XBLOCK_DELETED = OpenEdxPublicSignal(
@@ -82,6 +86,7 @@ XBLOCK_DELETED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.xblock.duplicated.v1
 # .. event_name: XBLOCK_DUPLICATED
+# .. event_key_field: xblock_info.usage_key
 # .. event_description: Fired when an XBlock is duplicated in Studio.
 # .. event_data: DuplicatedXBlockData
 XBLOCK_DUPLICATED = OpenEdxPublicSignal(

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -20,6 +20,7 @@ from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.content_authoring.course.catalog_info.changed.v1
 # .. event_name: COURSE_CATALOG_INFO_CHANGED
+# .. event_key_field: catalog_info.course_key
 # .. event_description: Fired when a course changes in Studio in a way that is relevant for catalog consumers.
 # .. event_data: CourseCatalogData
 COURSE_CATALOG_INFO_CHANGED = OpenEdxPublicSignal(

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -39,6 +39,7 @@ STUDENT_REGISTRATION_COMPLETED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.auth.session.login.completed.v1
 # .. event_name: SESSION_LOGIN_COMPLETED
+# .. event_key_field: user.pii.username
 # .. event_description: emitted when the user's login process in the LMS is completed.
 # .. event_data: UserData
 SESSION_LOGIN_COMPLETED = OpenEdxPublicSignal(
@@ -75,6 +76,7 @@ COURSE_ENROLLMENT_CHANGED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.course.unenrollment.completed.v1
 # .. event_name: COURSE_UNENROLLMENT_COMPLETED
+# .. event_key_field: enrollment.course.course_key
 # .. event_description: emitted when the user's unenrollment process is completed.
 # .. event_data: CourseEnrollmentData
 COURSE_UNENROLLMENT_COMPLETED = OpenEdxPublicSignal(
@@ -87,6 +89,7 @@ COURSE_UNENROLLMENT_COMPLETED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.certificate.created.v1
 # .. event_name: CERTIFICATE_CREATED
+# .. event_key_field: certificate.course.course_key
 # .. event_description: emitted when the user's certificate creation process is completed.
 # .. event_data: CertificateData
 CERTIFICATE_CREATED = OpenEdxPublicSignal(
@@ -98,6 +101,7 @@ CERTIFICATE_CREATED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.program.certificate.awarded.v1
 # .. event_name: PROGRAM_CERTIFICATE_AWARDED
+# .. event_key_field: program_certificate.program.uuid
 # .. event_description: Emit when a program certificate is awarded to a learner
 # .. event_data: ProgramCertificateData
 PROGRAM_CERTIFICATE_AWARDED = OpenEdxPublicSignal(
@@ -121,6 +125,7 @@ CERTIFICATE_CHANGED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.certificate.revoked.v1
 # .. event_name: CERTIFICATE_REVOKED
+# .. event_key_field: certificate.course.course_key
 # .. event_description: emitted when the user's certificate annulation process is completed.
 # .. event_data: CertificateData
 CERTIFICATE_REVOKED = OpenEdxPublicSignal(
@@ -132,6 +137,7 @@ CERTIFICATE_REVOKED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.program.certificate.revoked.v1
 # .. event_name: PROGRAM_CERTIFICATE_REVOKED
+# .. event_key_field: program_certificate.program.uuid
 # .. event_description: Emit when a program certificate is revoked from a learner
 # .. event_data: ProgramCertificateData
 PROGRAM_CERTIFICATE_REVOKED = OpenEdxPublicSignal(
@@ -179,6 +185,7 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.xblock.skill.verified.v1
 # .. event_name: XBLOCK_SKILL_VERIFIED
+# .. event_key_field: xblock_info.usage_key
 # .. event_description: Fired when an XBlock skill is verified.
 # .. event_data: XBlockSkillVerificationData
 XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
@@ -258,6 +265,7 @@ EXAM_ATTEMPT_RESET = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.user.course_access_role.added.v1
 # .. event_name: COURSE_ACCESS_ROLE_ADDED
+# .. event_key_field: course_access_role_data.course_key
 # .. event_description: Emitted when a user is given a course access role.
 # .. event_data: CourseAccessRoleData
 COURSE_ACCESS_ROLE_ADDED = OpenEdxPublicSignal(
@@ -269,6 +277,7 @@ COURSE_ACCESS_ROLE_ADDED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.learning.user.course_access_role.removed.v1
 # .. event_name: COURSE_ACCESS_ROLE_REMOVED
+# .. event_key_field: course_access_role_data.course_key
 # .. event_description: Emitted when a course access role is removed from a user.
 # .. event_data: CourseAccessRoleData
 COURSE_ACCESS_ROLE_REMOVED = OpenEdxPublicSignal(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,13 @@ asgiref==3.7.2
     # via django
 attrs==23.2.0
     # via -r requirements/base.in
+backports-zoneinfo==0.2.1
+    # via django
 cffi==1.16.0
     # via pynacl
 click==8.1.7
     # via edx-django-utils
-django==3.2.24
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -23,13 +25,13 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==4.1.0
     # via edx-django-utils
-edx-django-utils==5.10.1
+edx-django-utils==5.11.0
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.5.1
     # via -r requirements/base.in
 fastavro==1.9.4
     # via -r requirements/base.in
-newrelic==9.7.0
+newrelic==9.7.1
     # via edx-django-utils
 pbr==6.0.0
     # via stevedore
@@ -41,8 +43,6 @@ pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
-pytz==2024.1
-    # via django
 sqlparse==0.4.4
     # via django
 stevedore==5.2.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.3.2
+cachetools==5.3.3
     # via tox
 chardet==5.2.0
     # via tox
@@ -16,7 +16,7 @@ filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-packaging==23.2
+packaging==24.0
     # via
     #   pyproject-api
     #   tox
@@ -32,7 +32,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.13.0
+tox==4.14.1
     # via -r requirements/ci.in
 virtualenv==20.25.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,11 +16,15 @@ astroid==2.15.8
     #   pylint-celery
 attrs==23.2.0
     # via -r requirements/quality.txt
-build==1.0.3
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   django
+build==1.1.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.3.2
+cachetools==5.3.3
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -31,7 +35,6 @@ certifi==2024.2.2
 cffi==1.16.0
     # via
     #   -r requirements/quality.txt
-    #   cryptography
     #   pynacl
 chardet==5.2.0
     # via
@@ -55,7 +58,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==1.6.0
+code-annotations==1.7.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -67,10 +70,6 @@ coverage[toml]==7.4.3
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==42.0.5
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 ddt==1.7.2
     # via -r requirements/quality.txt
 diff-cover==8.0.3
@@ -83,7 +82,7 @@ distlib==0.3.8
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.24
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -102,7 +101,7 @@ docutils==0.20.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-django-utils==5.10.1
+edx-django-utils==5.11.0
     # via -r requirements/quality.txt
 edx-lint==5.3.6
     # via -r requirements/quality.txt
@@ -123,14 +122,15 @@ idna==3.6
     # via
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==7.0.1
+importlib-metadata==6.11.0
     # via
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
     #   keyring
     #   twine
-importlib-resources==6.1.2
+importlib-resources==6.3.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -146,17 +146,12 @@ jaraco-classes==3.3.1
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-keyring==24.3.0
+keyring==24.3.1
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -184,7 +179,7 @@ more-itertools==10.2.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
-newrelic==9.7.0
+newrelic==9.7.1
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -192,7 +187,7 @@ nh3==0.2.15
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -205,9 +200,9 @@ pbr==6.0.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via -r requirements/pip-tools.txt
-pkginfo==1.9.6
+pkginfo==1.10.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -280,7 +275,7 @@ pyproject-hooks==1.0.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.0.2
+pytest==8.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -293,10 +288,6 @@ python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2024.1
-    # via
-    #   -r requirements/quality.txt
-    #   django
 pyyaml==6.0.1
     # via
     #   -r requirements/quality.txt
@@ -318,14 +309,10 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.7.0
+rich==13.7.1
     # via
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/quality.txt
@@ -361,11 +348,11 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.13.0
+tox==4.14.1
     # via -r requirements/ci.txt
 twine==5.0.0
     # via -r requirements/quality.txt
@@ -386,7 +373,7 @@ virtualenv==20.25.1
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.42.0
+wheel==0.43.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -394,7 +381,7 @@ wrapt==1.16.0
     # via
     #   -r requirements/quality.txt
     #   astroid
-zipp==3.17.0
+zipp==3.18.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,7 +36,7 @@ click==8.1.7
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
-code-annotations==1.6.0
+git+https://github.com/openedx/code-annotations.git@bmtcril/add_openedx_events
     # via -r requirements/test.txt
 colorama==0.4.6
     # via sphinx-autobuild

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,16 +18,19 @@ babel==2.14.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   django
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
-build==1.0.3
+build==1.1.1
     # via -r requirements/doc.in
 certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
@@ -36,7 +39,7 @@ click==8.1.7
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
-git+https://github.com/openedx/code-annotations.git@bmtcril/add_openedx_events
+code-annotations==1.7.0
     # via -r requirements/test.txt
 colorama==0.4.6
     # via sphinx-autobuild
@@ -44,11 +47,9 @@ coverage[toml]==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-django==3.2.24
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -72,7 +73,7 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-django-utils==5.10.1
+edx-django-utils==5.11.0
     # via -r requirements/test.txt
 edx-opaque-keys[django]==2.5.1
     # via -r requirements/test.txt
@@ -86,13 +87,14 @@ idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==7.0.1
+importlib-metadata==6.11.0
     # via
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   build
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==6.1.2
+importlib-resources==6.3.0
     # via keyring
 iniconfig==2.0.0
     # via
@@ -100,16 +102,12 @@ iniconfig==2.0.0
     #   pytest
 jaraco-classes==3.3.1
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-keyring==24.3.0
+keyring==24.3.1
     # via twine
 livereload==2.6.3
     # via sphinx-autobuild
@@ -123,13 +121,13 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.2.0
     # via jaraco-classes
-newrelic==9.7.0
+newrelic==9.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 nh3==0.2.15
     # via readme-renderer
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements/test.txt
     #   build
@@ -140,7 +138,7 @@ pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.9.6
+pkginfo==1.10.0
     # via twine
 pluggy==1.4.0
     # via
@@ -174,7 +172,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==8.0.2
+pytest==8.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -188,10 +186,7 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
 pytz==2024.1
-    # via
-    #   -r requirements/test.txt
-    #   babel
-    #   django
+    # via babel
 pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
@@ -209,10 +204,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.7.0
+rich==13.7.1
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via livereload
 snowballstemmer==2.2.0
@@ -287,7 +280,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-zipp==3.17.0
+zipp==3.18.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,15 +4,17 @@
 #
 #    make upgrade
 #
-build==1.0.3
+build==1.1.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==7.0.1
+importlib-metadata==6.11.0
+    # via
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   build
+packaging==24.0
     # via build
-packaging==23.2
-    # via build
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via
@@ -23,9 +25,9 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
-zipp==3.17.0
+zipp==3.18.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.42.0
+wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.1.1
+setuptools==69.2.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,12 +15,15 @@ astroid==2.15.8
     #   pylint-celery
 attrs==23.2.0
     # via -r requirements/test.txt
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   django
 certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
@@ -33,7 +36,7 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.6.0
+code-annotations==1.7.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -41,13 +44,11 @@ coverage[toml]==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==42.0.5
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.3.8
     # via pylint
-django==3.2.24
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -64,7 +65,7 @@ django-waffle==4.1.0
     #   edx-django-utils
 docutils==0.20.1
     # via readme-renderer
-edx-django-utils==5.10.1
+edx-django-utils==5.11.0
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/quality.in
@@ -78,11 +79,12 @@ fastavro==1.9.4
     # via -r requirements/test.txt
 idna==3.6
     # via requests
-importlib-metadata==7.0.1
+importlib-metadata==6.11.0
     # via
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   keyring
     #   twine
-importlib-resources==6.1.2
+importlib-resources==6.3.0
     # via keyring
 iniconfig==2.0.0
     # via
@@ -94,15 +96,11 @@ isort==5.13.2
     #   pylint
 jaraco-classes==3.3.1
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-keyring==24.3.0
+keyring==24.3.1
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -118,13 +116,13 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.2.0
     # via jaraco-classes
-newrelic==9.7.0
+newrelic==9.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 nh3==0.2.15
     # via readme-renderer
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -132,7 +130,7 @@ pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.9.6
+pkginfo==1.10.0
     # via twine
 platformdirs==4.2.0
     # via pylint
@@ -178,7 +176,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==8.0.2
+pytest==8.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -191,10 +189,6 @@ python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2024.1
-    # via
-    #   -r requirements/test.txt
-    #   django
 pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
@@ -209,10 +203,8 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.7.0
+rich==13.7.1
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
@@ -237,7 +229,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
 twine==5.0.0
     # via -r requirements/quality.in
@@ -255,7 +247,7 @@ urllib3==2.2.1
     #   twine
 wrapt==1.16.0
     # via astroid
-zipp==3.17.0
+zipp==3.18.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,4 +6,4 @@
 ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
-code-annotations          # provides commands used by the pii_check make target.
+https://github.com/openedx/code-annotations.git@bmtcril/add_openedx_events

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,4 +6,4 @@
 ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
-https://github.com/openedx/code-annotations.git@bmtcril/add_openedx_events
+code-annotations==1.7.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ click==8.1.7
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
-code-annotations==1.6.0
+git+https://github.com/openedx/code-annotations.git@bmtcril/add_openedx_events
     # via -r requirements/test.in
 coverage[toml]==7.4.3
     # via pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,10 @@ asgiref==3.7.2
     #   django
 attrs==23.2.0
     # via -r requirements/base.txt
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/base.txt
+    #   django
 cffi==1.16.0
     # via
     #   -r requirements/base.txt
@@ -19,7 +23,7 @@ click==8.1.7
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
-git+https://github.com/openedx/code-annotations.git@bmtcril/add_openedx_events
+code-annotations==1.7.0
     # via -r requirements/test.in
 coverage[toml]==7.4.3
     # via pytest-cov
@@ -39,7 +43,7 @@ django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.10.1
+edx-django-utils==5.11.0
     # via -r requirements/base.txt
 edx-opaque-keys[django]==2.5.1
     # via -r requirements/base.txt
@@ -53,11 +57,11 @@ jinja2==3.1.3
     # via code-annotations
 markupsafe==2.1.5
     # via jinja2
-newrelic==9.7.0
+newrelic==9.7.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-packaging==23.2
+packaging==24.0
     # via pytest
 pbr==6.0.0
     # via
@@ -81,7 +85,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==8.0.2
+pytest==8.1.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -91,10 +95,6 @@ pytest-django==4.8.0
     # via -r requirements/test.in
 python-slugify==8.0.4
     # via code-annotations
-pytz==2024.1
-    # via
-    #   -r requirements/base.txt
-    #   django
 pyyaml==6.0.1
     # via code-annotations
 sqlparse==0.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -79,11 +79,3 @@ commands =
     pydocstyle openedx_events tests manage.py setup.py
     isort --check-only --diff tests test_utils openedx_events manage.py setup.py
     make selfcheck
-
-[testenv:pii_check]
-setenv =
-    DJANGO_SETTINGS_MODULE = test_utils.test_settings
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands =
-    code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
**Description:** Adds automatic documentation of annotated events for discoverability and ease of configuration. This is in draft until dependencies merge and release, so I can update requirements to the official version, I'll be adding event_key_fields for the rest of the events while that is in review. Generated docs look like this:

<img width="1374" alt="Screenshot 2024-02-20 at 1 11 21 PM" src="https://github.com/openedx/openedx-events/assets/112640379/c1a16ddc-cbfd-4c75-b2e7-7b6c3e57901e">


**Dependencies:** https://github.com/openedx/code-annotations/pull/98

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Requirements are updated to use the branch of code-annotations necessary to run this so pulling this branch and running `make requirements` should suffice
2. Run `make docs`
3. Sphinx should run and pop open the generated docs in your browser. Navigate to reference -> events to see the content.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
