### PR TITLE
[FC-0040] feat: Add `CONTENT_OBJECT_TAGS_CHANGED` signal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ----------
+Added
+~~~~~
+* Added new ``CONTENT_OBJECT_TAGGED`` events in content_authoring.
 
 [9.5.2] - 2024-02-13
 --------------------

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.5.2"
+__version__ = "9.6.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -180,3 +180,17 @@ class LibraryBlockData:
 
     library_key = attr.ib(type=LibraryLocatorV2)
     usage_key = attr.ib(type=LibraryUsageLocatorV2)
+
+
+@attr.s(frozen=True)
+class ContentObjectData:
+    """
+    Data about changed content object
+
+    Arguments:
+        object_id (str): identifier of the Content object. This represents the id of the course or library block
+        as a string. For example:
+        block-v1:SampleTaxonomyOrg2+STC1+2023_1+type@vertical+block@f8de78f0897049ce997777a3a31b6ea0
+    """
+
+    object_id = attr.ib(type=str)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -10,6 +10,7 @@ docs/decisions/0003-events-payload.rst
 from openedx_events.content_authoring.data import (
     CertificateConfigData,
     ContentLibraryData,
+    ContentObjectData,
     CourseCatalogData,
     CourseData,
     DuplicatedXBlockData,
@@ -196,5 +197,16 @@ LIBRARY_BLOCK_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.library_block.deleted.v1",
     data={
         "library_block": LibraryBlockData,
+    }
+)
+
+# .. event_type: org.openedx.content_authoring.content.object.tags.changed.v1
+# .. event_name: CONTENT_OBJECT_TAGS_CHANGED
+# .. event_description: emitted when an object's tags are changed
+# .. event_data: ContentObjectData
+CONTENT_OBJECT_TAGS_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.content.object.tags.changed.v1",
+    data={
+        "content_object": ContentObjectData
     }
 )

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content+object+tags+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content+object+tags+changed+v1_schema.avsc
@@ -1,0 +1,21 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "content_object",
+      "type": {
+        "name": "ContentObjectData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "object_id",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.content.object.tags.changed.v1"
+}


### PR DESCRIPTION
This signal is emitted when tags on a content object have changed.

**Description:** This PR adds a new `CONTENT_OBJECT_TAGGED` signal, which is emitted when a content object's tags have changed.

**ISSUE:** https://github.com/openedx/modular-learning/issues/197

**Dependencies:**
- Needed for edx-platform: https://github.com/open-craft/edx-platform/pull/647

**Testing instructions:**

Follow instructions mentioned in https://github.com/open-craft/edx-platform/pull/647

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.

---
Private-ref: [FAL-3691](https://tasks.opencraft.com/browse/FAL-3691)