### PR TITLE
feat: Added enterprise subsidy events. OEP-49

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,16 @@ Change Log
 
 Unreleased
 ----------
+[9.7.0] - 2024-04-04
+--------------------
 Added
-~~~~~
+~~~~~~~
+* Added new ``SUBSIDY_REDEEMED`` and ``SUBSIDY_REDEMPTION_REVERSED`` events in enterprise.
+
+[9.6.0] - 2024-04-01
+--------------------
+Added
+~~~~~~~
 * Added new ``CONTENT_OBJECT_TAGGED`` events in content_authoring.
 
 [9.5.2] - 2024-02-13

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.6.0"
+__version__ = "9.7.0"

--- a/openedx_events/enterprise/__init__.py
+++ b/openedx_events/enterprise/__init__.py
@@ -1,0 +1,6 @@
+"""
+Package where events related to the enterprise subdomain are implemented.
+
+The enterprise subdomain corresponds to {Architecture Subdomain} defined in
+the OEP-41.
+"""

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -1,0 +1,24 @@
+"""
+Data attributes for events within the architecture subdomain ``enterprise``.
+
+These attributes follow the form of attr objects specified in OEP-49 data
+pattern.
+"""
+
+import attr
+
+
+@attr.s(frozen=True)
+class SubsidyRedemption:
+    """
+    Attributes for a Subsidy Redemption object.
+
+    Arguments:
+        subsidy_identifier (str): unique identifier to fetch the applied subsidy
+        content_key (str): content id where subsidy is utilized
+        lms_user_id (str): lms user id of subsidy beneficiary
+    """
+
+    subsidy_identifier = attr.ib(type=str)
+    content_key = attr.ib(type=str)
+    lms_user_id = attr.ib(type=int)

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -1,0 +1,34 @@
+"""
+Standardized signals definitions for events within the architecture subdomain ``enterprise``.
+
+All signals defined in this module must follow the name and versioning
+conventions specified in OEP-41.
+
+They also must comply with the payload definition specified in
+docs/decisions/0003-events-payload.rst
+"""
+
+from openedx_events.enterprise.data import SubsidyRedemption
+from openedx_events.tooling import OpenEdxPublicSignal
+
+# .. event_type: org.openedx.enterprise.subsidy.redeemed.v1
+# .. event_name: SUBSIDY_REDEEMED
+# .. event_description: emitted when an enterprise subsidy is utilized.
+# .. event_data: SubsidyRedemption
+SUBSIDY_REDEEMED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.subsidy.redeemed.v1",
+    data={
+        "redemption": SubsidyRedemption,
+    }
+)
+
+# .. event_type: org.openedx.enterprise.subsidy.redemption-reversed.v1
+# .. event_name: SUBSIDY_REDEMPTION_REVERSED
+# .. event_description: emitted when an enterprise subsidy is reversed.
+# .. event_data: SubsidyRedemption
+SUBSIDY_REDEMPTION_REVERSED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.subsidy.redemption-reversed.v1",
+    data={
+        "redemption": SubsidyRedemption,
+    }
+)

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy+redeemed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy+redeemed+v1_schema.avsc
@@ -1,0 +1,29 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "redemption",
+      "type": {
+        "name": "SubsidyRedemption",
+        "type": "record",
+        "fields": [
+          {
+            "name": "subsidy_identifier",
+            "type": "string"
+          },
+          {
+            "name": "content_key",
+            "type": "string"
+          },
+          {
+            "name": "lms_user_id",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.subsidy.redeemed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy+redemption-reversed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy+redemption-reversed+v1_schema.avsc
@@ -1,0 +1,29 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "redemption",
+      "type": {
+        "name": "SubsidyRedemption",
+        "type": "record",
+        "fields": [
+          {
+            "name": "subsidy_identifier",
+            "type": "string"
+          },
+          {
+            "name": "content_key",
+            "type": "string"
+          },
+          {
+            "name": "lms_user_id",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.subsidy.redemption-reversed.v1"
+}


### PR DESCRIPTION
**Description:** This PR adds OEP-49 data and signals for learner enrollment fee subsidies provided by enterprises. 

**Issue**: Enterprises provide subsidies to their learners for enrollment. These subsidies are managed via enterprise related repositories such as [enterprise-access](https://github.com/openedx/enterprise-access), [enterprise-subsidy](https://github.com/openedx/enterprise-subsidy), [openedx-ledger](https://github.com/openedx/openedx-ledger). The subsidy redemption and reversal events would be produced/consumed in these repositories for enterprise budget adjustments.

**Reference Usage**
https://github.com/openedx/enterprise-subsidy/pull/227
https://github.com/openedx/enterprise-access/pull/434

**Reviewers:**
- [x] tag reviewer
- [x] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
