### PR TITLE
refactor: update ora submission data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[9.9.2] - 2024-04-18
+--------------------
+
+Changed
+~~~~~~~
+
+* Updated ``ORASubmissionData`` class.
+
 [9.9.1] - 2024-04-12
 --------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.9.1"
+__version__ = "9.9.2"

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -465,14 +465,49 @@ class ORAFileDownloadsData:
 
 
 @attr.s(frozen=True)
+class ORASubmissionAnswer:
+    """
+    Attributes defined to represent the answer submitted by the user in an ORA submission.
+
+    Arguments:
+        parts (List[dict]): List with the response text in the ORA submission.
+
+        The following attributes are used to represent the files submitted in the ORA submission:
+
+        file_keys (List[str]): List of file keys in the ORA submission.
+        file_descriptions (List[str]): List of file descriptions in the ORA submission.
+        file_names (List[str]): List of file names in the ORA submission.
+        file_sizes (List[int]): List of file sizes in the ORA submission.
+        file_urls (List[str]): List of file URLs in the ORA submission.
+    """
+
+    parts = attr.ib(type=List[dict], factory=list)
+    file_keys = attr.ib(type=List[str], factory=list)
+    file_descriptions = attr.ib(type=List[str], factory=list)
+    file_names = attr.ib(type=List[str], factory=list)
+    file_sizes = attr.ib(type=List[int], factory=list)
+    file_urls = attr.ib(type=List[str], factory=list)
+
+
+@attr.s(frozen=True)
 class ORASubmissionData:
     """
     Attributes defined to represent event when a user submits an ORA assignment.
 
     Arguments:
-        id (str): identifier of the ORA submission.
-        file_downloads (List[ORAFileDownloadsData]): list of related files in the ORA submission.
+        uuid (str): The UUID of the ORA submission.
+        anonymous_user_id (str): Optional. Anonymous user ID of the user who submitted the ORA submission.
+        location (str): Optional. Location of the ORA submission.
+        attempt_number (int): Attempt number of the ORA submission.
+        created_at (datetime): Date and time when the ORA submission was created.
+        submitted_at (datetime): Date and time when the ORA submission was submitted.
+        answer (ORASubmissionAnswer): Answer submitted by the user in the ORA submission.
     """
 
-    id = attr.ib(type=str)
-    file_downloads = attr.ib(type=List[ORAFileDownloadsData], factory=list)
+    uuid = attr.ib(type=str)
+    anonymous_user_id = attr.ib(type=str)
+    location = attr.ib(type=str)
+    attempt_number = attr.ib(type=int)
+    created_at = attr.ib(type=datetime)
+    submitted_at = attr.ib(type=datetime)
+    answer = attr.ib(type=ORASubmissionAnswer)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -447,24 +447,6 @@ class CourseNotificationData:
 
 
 @attr.s(frozen=True)
-class ORAFileDownloadsData:
-    """
-    Attributes defined to represent file downloads in an ORA submission.
-
-    Arguments:
-        download_url (str): URL to download the file.
-        description (str): Description of the file.
-        name (str): Name of the file.
-        size (int): Size of the file.
-    """
-
-    download_url = attr.ib(type=str)
-    description = attr.ib(type=str)
-    name = attr.ib(type=str)
-    size = attr.ib(type=int)
-
-
-@attr.s(frozen=True)
 class ORASubmissionAnswer:
     """
     Attributes defined to represent the answer submitted by the user in an ORA submission.


### PR DESCRIPTION
### Description
This PR updates the `ORASubmissionData` class to send the same data as the [legacy analytics event](https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/apis/submissions/submissions_actions.py#L162-L171). This will facilitate the transition from one event to another if necessary.

> [!NOTE]
> As this is an event that has not been used yet, there will be no problem in adding these new fields.


The new class attributes are:
- `id` -> `uuid` (Renamed to maintain consistency with the legacy event)
- `anonymous_user_id`
- `location`
- `attempt_number`
- `created_at`
- `submitted_at`
- `answer` (`ORASubmissionAnswer`)
    - `parts`
    - `file_keys`
    - `file_descriptions`
    - `file_names`
    - `file_sizes`
    - `file_urls`

The new fields that are not in the legacy event are:
- `anonymous_user_id`: Anonymous user ID of the user who submitted the ORA submission.
- `location`: Location of the ORA submission.

This new data is important as it allows us to have more complete and detailed information on ORA submission at the event.