### PR TITLE
feat: new enterprise transaction data/signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ requirements/private.txt
 
 # IDA cruft
 .idea
+
+# emacs backup files
+*~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,17 @@ Change Log
 Unreleased
 ----------
 
+[9.11.0] - 2024-05-15
+---------------------
+
+Added
+~~~~~~~
+
+* Added new enterprise signals ``LEDGER_TRANSACTION_CREATED``, ``LEDGER_TRANSACTION_COMMITTED``,
+  ``LEDGER_TRANSACTION_FAILED``, and ``LEDGER_TRANSACTION_REVERSED``.
+* Added a ``UuidAvroSerializer`` to serialize uuid fields.
+* Added ``isort`` make target.
+
 [9.10.0] - 2024-05-08
 ---------------------
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ test-all: quality ## run tests on every supported Python/Django combination
 
 validate: quality test ## run tests and quality checks
 
+isort:  ## fix improperly sorted imports
+	isort test_utils openedx_events manage.py setup.py
+
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.10.0"
+__version__ = "9.11.0"

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -4,8 +4,11 @@ Data attributes for events within the architecture subdomain ``enterprise``.
 These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
+from datetime import datetime
+from uuid import UUID
 
 import attr
+from opaque_keys.edx.keys import CourseKey
 
 
 @attr.s(frozen=True)
@@ -22,3 +25,72 @@ class SubsidyRedemption:
     subsidy_identifier = attr.ib(type=str)
     content_key = attr.ib(type=str)
     lms_user_id = attr.ib(type=int)
+
+
+@attr.s(frozen=True)
+class BaseLedgerTransaction:
+    """
+    Defines the common attributes of the transaction classes below.
+    """
+
+    uuid = attr.ib(type=UUID)
+    created = attr.ib(type=datetime)
+    modified = attr.ib(type=datetime)
+    idempotency_key = attr.ib(type=str)
+    quantity = attr.ib(type=int)
+    state = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
+class LedgerTransactionReversal(BaseLedgerTransaction):
+    """
+    Attributes of an ``openedx_ledger.Reversal`` record.
+
+    A ``Reversal`` is a model that represents the "undo-ing" of a ``Transaction`` (see below). It's primarily
+    used within the domain of edX Enterprise for recording unenrollments and refunds of subsidized
+    enterprise enrollments.
+    https://github.com/openedx/openedx-ledger/blob/master/openedx_ledger/models.py
+
+    Arguments:
+        uuid (str): Primary identifier of the record.
+        created (datetime): When the record was created.
+        modified (datetime): When the record was last modified.
+        idempotency_key (str): Client-generated unique value to achieve idempotency of operations.
+        quantity (int): How many units of value this reversal represents (e.g. USD cents).
+        state (str): Current lifecyle state of the record, one of (created, pending, committed, failed).
+    """
+
+
+@attr.s(frozen=True)
+class LedgerTransaction(BaseLedgerTransaction):
+    """
+    Attributes of an ``openedx_ledger.Transaction`` record.
+
+    A ``Transaction`` is a model that represents value moving in or out of a ``Ledger``. It's primarily
+    used within the domain of edX Enterprise for recording the redemption of subsidized enrollments.
+    https://github.com/openedx/openedx-ledger/blob/master/openedx_ledger/models.py
+
+    Arguments:
+        uuid (UUID): Primary identifier of the Transaction.
+        created (datetime): When the record was created.
+        modified (datetime): When the record was last modified.
+        idempotency_key (str): Client-generated unique value to achieve idempotency of operations.
+        quantity (int): How many units of value this transaction represents (e.g. USD cents).
+        state (str): Current lifecyle state of the record, one of (created, pending, committed, failed).
+        ledger_uuid (UUID): The primary identifier of this Transaction's ledger object.
+        subsidy_access_policy_uuid (UUID): The primary identifier of the subsidy access policy for this transaction.
+        lms_user_id (int): The LMS user id of the user associated with this transaction.
+        content_key (CourseKey): The course (run) key associated with this transaction.
+        parent_content_key (str): The parent (just course, not run) key for the course key.
+        fulfillment_identifier (str): The identifier of the subsidized enrollment record for a learner,
+          generated durning enrollment.
+        reversal (LedgerTransactionReversal): Any reversal associated with this transaction.
+    """
+
+    ledger_uuid = attr.ib(type=UUID)
+    subsidy_access_policy_uuid = attr.ib(type=UUID)
+    lms_user_id = attr.ib(type=int)
+    content_key = attr.ib(type=CourseKey)
+    parent_content_key = attr.ib(type=str, default=None)
+    fulfillment_identifier = attr.ib(type=str, default=None)
+    reversal = attr.ib(type=LedgerTransactionReversal, default=None)

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -8,7 +8,7 @@ They also must comply with the payload definition specified in
 docs/decisions/0003-events-payload.rst
 """
 
-from openedx_events.enterprise.data import SubsidyRedemption
+from openedx_events.enterprise.data import LedgerTransaction, SubsidyRedemption
 from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.enterprise.subsidy.redeemed.v1
@@ -30,5 +30,57 @@ SUBSIDY_REDEMPTION_REVERSED = OpenEdxPublicSignal(
     event_type="org.openedx.enterprise.subsidy.redemption-reversed.v1",
     data={
         "redemption": SubsidyRedemption,
+    }
+)
+
+
+# .. event_type: org.openedx.enterprise.subsidy_ledger_transaction.created.v1
+# .. event_name: LEDGER_TRANSACTION_CREATED
+# .. event_description: emitted when an enterprise ledger transaction is created.
+#      See: https://github.com/openedx/openedx-ledger/tree/main/docs/decisions
+# .. event_data: LedgerTransaction
+LEDGER_TRANSACTION_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.subsidy_ledger_transaction.created.v1",
+    data={
+        "ledger_transaction": LedgerTransaction,
+    }
+)
+
+
+# .. event_type: org.openedx.enterprise.subsidy_ledger_transaction.committed.v1
+# .. event_name: LEDGER_TRANSACTION_COMMITTED
+# .. event_description: emitted when an enterprise ledger transaction is committed.
+#      See: https://github.com/openedx/openedx-ledger/tree/main/docs/decisions
+# .. event_data: LedgerTransaction
+LEDGER_TRANSACTION_COMMITTED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.subsidy_ledger_transaction.committed.v1",
+    data={
+        "ledger_transaction": LedgerTransaction,
+    }
+)
+
+
+# .. event_type: org.openedx.enterprise.subsidy_ledger_transaction.failed.v1
+# .. event_name: LEDGER_TRANSACTION_FAILED
+# .. event_description: emitted when an enterprise ledger transaction fails.
+#      See: https://github.com/openedx/openedx-ledger/tree/main/docs/decisions
+# .. event_data: LedgerTransaction
+LEDGER_TRANSACTION_FAILED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.subsidy_ledger_transaction.failed.v1",
+    data={
+        "ledger_transaction": LedgerTransaction,
+    }
+)
+
+
+# .. event_type: org.openedx.enterprise.subsidy_ledger_transaction.reversed.v1
+# .. event_name: LEDGER_TRANSACTION_REVERSED
+# .. event_description: emitted when an enterprise ledger transaction is reversed.
+#      See: https://github.com/openedx/openedx-ledger/tree/main/docs/decisions
+# .. event_data: LedgerTransaction
+LEDGER_TRANSACTION_REVERSED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.subsidy_ledger_transaction.reversed.v1",
+    data={
+        "ledger_transaction": LedgerTransaction,
     }
 )

--- a/openedx_events/event_bus/avro/custom_serializers.py
+++ b/openedx_events/event_bus/avro/custom_serializers.py
@@ -4,6 +4,7 @@ Classes to serialize and deserialize custom types used by openedx events. See RE
 """
 from abc import ABC, abstractmethod
 from datetime import datetime
+from uuid import UUID
 
 from ccx_keys.locator import CCXLocator
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -149,6 +150,27 @@ class LibraryUsageLocatorV2AvroSerializer(BaseCustomTypeAvroSerializer):
         return LibraryUsageLocatorV2.from_string(data)
 
 
+class UuidAvroSerializer(BaseCustomTypeAvroSerializer):
+    """
+    CustomTypeAvroSerializer for the UUID class.
+
+    https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/avro-format.md#21-type-system-mapping
+    """
+
+    cls = UUID
+    field_type = PYTHON_TYPE_TO_AVRO_MAPPING[str]
+
+    @staticmethod
+    def serialize(obj) -> str:
+        """Serialize obj into string."""
+        return str(obj)
+
+    @staticmethod
+    def deserialize(data: str):
+        """Deserialize string into obj."""
+        return UUID(data)
+
+
 DEFAULT_CUSTOM_SERIALIZERS = [
     CourseKeyAvroSerializer,
     CcxCourseLocatorAvroSerializer,
@@ -156,4 +178,5 @@ DEFAULT_CUSTOM_SERIALIZERS = [
     LibraryLocatorV2AvroSerializer,
     LibraryUsageLocatorV2AvroSerializer,
     UsageKeyAvroSerializer,
+    UuidAvroSerializer,
 ]

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+committed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+committed+v1_schema.avsc
@@ -1,0 +1,110 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "ledger_transaction",
+      "type": {
+        "name": "LedgerTransaction",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": "string"
+          },
+          {
+            "name": "created",
+            "type": "string"
+          },
+          {
+            "name": "modified",
+            "type": "string"
+          },
+          {
+            "name": "idempotency_key",
+            "type": "string"
+          },
+          {
+            "name": "quantity",
+            "type": "long"
+          },
+          {
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "name": "ledger_uuid",
+            "type": "string"
+          },
+          {
+            "name": "subsidy_access_policy_uuid",
+            "type": "string"
+          },
+          {
+            "name": "lms_user_id",
+            "type": "long"
+          },
+          {
+            "name": "content_key",
+            "type": "string"
+          },
+          {
+            "name": "parent_content_key",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "fulfillment_identifier",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "reversal",
+            "type": [
+              "null",
+              {
+                "name": "LedgerTransactionReversal",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uuid",
+                    "type": "string"
+                  },
+                  {
+                    "name": "created",
+                    "type": "string"
+                  },
+                  {
+                    "name": "modified",
+                    "type": "string"
+                  },
+                  {
+                    "name": "idempotency_key",
+                    "type": "string"
+                  },
+                  {
+                    "name": "quantity",
+                    "type": "long"
+                  },
+                  {
+                    "name": "state",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.subsidy_ledger_transaction.committed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+created+v1_schema.avsc
@@ -1,0 +1,110 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "ledger_transaction",
+      "type": {
+        "name": "LedgerTransaction",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": "string"
+          },
+          {
+            "name": "created",
+            "type": "string"
+          },
+          {
+            "name": "modified",
+            "type": "string"
+          },
+          {
+            "name": "idempotency_key",
+            "type": "string"
+          },
+          {
+            "name": "quantity",
+            "type": "long"
+          },
+          {
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "name": "ledger_uuid",
+            "type": "string"
+          },
+          {
+            "name": "subsidy_access_policy_uuid",
+            "type": "string"
+          },
+          {
+            "name": "lms_user_id",
+            "type": "long"
+          },
+          {
+            "name": "content_key",
+            "type": "string"
+          },
+          {
+            "name": "parent_content_key",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "fulfillment_identifier",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "reversal",
+            "type": [
+              "null",
+              {
+                "name": "LedgerTransactionReversal",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uuid",
+                    "type": "string"
+                  },
+                  {
+                    "name": "created",
+                    "type": "string"
+                  },
+                  {
+                    "name": "modified",
+                    "type": "string"
+                  },
+                  {
+                    "name": "idempotency_key",
+                    "type": "string"
+                  },
+                  {
+                    "name": "quantity",
+                    "type": "long"
+                  },
+                  {
+                    "name": "state",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.subsidy_ledger_transaction.created.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+failed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+failed+v1_schema.avsc
@@ -1,0 +1,110 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "ledger_transaction",
+      "type": {
+        "name": "LedgerTransaction",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": "string"
+          },
+          {
+            "name": "created",
+            "type": "string"
+          },
+          {
+            "name": "modified",
+            "type": "string"
+          },
+          {
+            "name": "idempotency_key",
+            "type": "string"
+          },
+          {
+            "name": "quantity",
+            "type": "long"
+          },
+          {
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "name": "ledger_uuid",
+            "type": "string"
+          },
+          {
+            "name": "subsidy_access_policy_uuid",
+            "type": "string"
+          },
+          {
+            "name": "lms_user_id",
+            "type": "long"
+          },
+          {
+            "name": "content_key",
+            "type": "string"
+          },
+          {
+            "name": "parent_content_key",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "fulfillment_identifier",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "reversal",
+            "type": [
+              "null",
+              {
+                "name": "LedgerTransactionReversal",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uuid",
+                    "type": "string"
+                  },
+                  {
+                    "name": "created",
+                    "type": "string"
+                  },
+                  {
+                    "name": "modified",
+                    "type": "string"
+                  },
+                  {
+                    "name": "idempotency_key",
+                    "type": "string"
+                  },
+                  {
+                    "name": "quantity",
+                    "type": "long"
+                  },
+                  {
+                    "name": "state",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.subsidy_ledger_transaction.failed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+reversed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+subsidy_ledger_transaction+reversed+v1_schema.avsc
@@ -1,0 +1,110 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "ledger_transaction",
+      "type": {
+        "name": "LedgerTransaction",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": "string"
+          },
+          {
+            "name": "created",
+            "type": "string"
+          },
+          {
+            "name": "modified",
+            "type": "string"
+          },
+          {
+            "name": "idempotency_key",
+            "type": "string"
+          },
+          {
+            "name": "quantity",
+            "type": "long"
+          },
+          {
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "name": "ledger_uuid",
+            "type": "string"
+          },
+          {
+            "name": "subsidy_access_policy_uuid",
+            "type": "string"
+          },
+          {
+            "name": "lms_user_id",
+            "type": "long"
+          },
+          {
+            "name": "content_key",
+            "type": "string"
+          },
+          {
+            "name": "parent_content_key",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "fulfillment_identifier",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "reversal",
+            "type": [
+              "null",
+              {
+                "name": "LedgerTransactionReversal",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "uuid",
+                    "type": "string"
+                  },
+                  {
+                    "name": "created",
+                    "type": "string"
+                  },
+                  {
+                    "name": "modified",
+                    "type": "string"
+                  },
+                  {
+                    "name": "idempotency_key",
+                    "type": "string"
+                  },
+                  {
+                    "name": "quantity",
+                    "type": "long"
+                  },
+                  {
+                    "name": "state",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.subsidy_ledger_transaction.reversed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 from typing import List
 from unittest import TestCase
+from uuid import UUID, uuid4
 
 from ccx_keys.locator import CCXLocator
 from fastavro import schemaless_reader, schemaless_writer
@@ -109,6 +110,7 @@ def generate_test_event_data_for_data_type(data_type):  # pragma: no cover
         List[int]: [1, 2, 3],
         datetime: datetime.now(),
         CCXLocator: CCXLocator(org='edx', course='DemoX', run='Demo_course', ccx='1'),
+        UUID: uuid4(),
     }
     data_dict = {}
     for attribute in data_type.__attrs_attrs__:

--- a/openedx_events/event_bus/avro/tests/test_custom_serializers.py
+++ b/openedx_events/event_bus/avro/tests/test_custom_serializers.py
@@ -1,9 +1,10 @@
 """Test custom servializers"""
 from unittest import TestCase
+from uuid import UUID, uuid4
 
 from ccx_keys.locator import CCXLocator
 
-from openedx_events.event_bus.avro.custom_serializers import CcxCourseLocatorAvroSerializer
+from openedx_events.event_bus.avro.custom_serializers import CcxCourseLocatorAvroSerializer, UuidAvroSerializer
 
 
 class TestCCXLocatorSerailizer(TestCase):
@@ -19,7 +20,7 @@ class TestCCXLocatorSerailizer(TestCase):
         result1 = CcxCourseLocatorAvroSerializer.serialize(obj1)
         self.assertEqual(result1, expected1)
 
-    def test_deseialize(self):
+    def test_deserialize(self):
         """
         Test case for deserializing CCXLocator object.
         """
@@ -28,3 +29,26 @@ class TestCCXLocatorSerailizer(TestCase):
         expected1 = CCXLocator(org="edx", course="DemoX", run="Demo_course", ccx="1")
         result1 = CcxCourseLocatorAvroSerializer.deserialize(data1)
         self.assertEqual(result1, expected1)
+
+
+class TestUuidAvroSerializer(TestCase):
+    """
+    Tests case for Avro UUID de-/serialization.
+    """
+    def test_serialize(self):
+        """
+        Test UUID Avro serialization.
+        """
+        some_uuid = uuid4()
+        expected_result = str(some_uuid)
+        actual_result = UuidAvroSerializer.serialize(some_uuid)
+        self.assertEqual(actual_result, expected_result)
+
+    def test_deserialize(self):
+        """
+        Test UUID Avro de-serialization.
+        """
+        uuid_str = str(uuid4())
+        expected_result = UUID(uuid_str)
+        actual_result = UuidAvroSerializer.deserialize(uuid_str)
+        self.assertEqual(actual_result, expected_result)


### PR DESCRIPTION
* Added new enterprise signals `LEDGER_TRANSACTION_CREATED`, `LEDGER_TRANSACTION_COMMITTED`, `LEDGER_TRANSACTION_FAILED`, and `LEDGER_TRANSACTION_REVERSED`.
* Added a `UuidAvroSerializer` to serialize uuid fields.
* Added `isort` make target.

## Context
The best doc to start with is probably this: https://github.com/openedx/enterprise-access/blob/main/docs/decisions/0004-add-access-policy-functionality.rst#context

A Ledger is a model defined in the openedx-ledger repo, it's a core model used in the context of edX Enterprise. https://github.com/openedx/openedx-ledger/blob/main/docs/decisions/0002-ledger-balance-enforcement.rst

It's installed only into enterprise-subsidy AFAIK: https://github.com/openedx/enterprise-subsidy/tree/main/docs/decisions

I don't believe ledgers (or enterprise-subsidy,access) to be used widely by the community - my guess is that 2u is the only entity currently using it.
These new events will be used to relay state transitions from enterprise-subsidy back to enterprise-access so that a related record, LearnerContentAssignment, can update its state based on the new state of its related transaction.
https://github.com/openedx/enterprise-access/blob/main/docs/decisions/0012-assignment-based-policies.rst
https://github.com/openedx/enterprise-access/blob/430d768ee4c6355b353e22f5b0f7902d169850bc/enterprise_access/apps/content_assignments/models.py#L234

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
