### PR TITLE
ci: upgrade os and python-version from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python-version: ['3.8', '3.11']
+        os: [ubuntu-20.04, ubuntu-24.04]
+        python-version: ['3.11', '3.12']
         toxenv: ["django42", "quality", "docs"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-24.04]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11']
         toxenv: ["django42", "quality", "docs"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.11',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38, 311}-django{42}, quality, docs
+envlist = py{311}-django{42}, quality, docs
 
 [doc8]
 ignore = D001


### PR DESCRIPTION
### Description
Upgrade stack versions from CI matrix so it handles the project's latest supported versions. Also, this solves errors we've been having while upgrading Python requirements since requirements are now updated using Python3.11 exclusively: https://github.com/openedx/openedx-events/pull/391
