### PR TITLE
fix: make nullable django fields also Noneable in event data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,14 @@ __________
 
 
 
+[9.14.1] - 2024-09-17
+---------------------
+
+Changed
+~~~~~~~
+
+* Fixed event ``LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED`` so that its serializer can tolerate null nullable fields.
+
 [9.14.0] - 2024-09-12
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.14.0"
+__version__ = "9.14.1"

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -125,8 +125,8 @@ class EnterpriseCustomerUser:
     active = attr.ib(type=bool)
     linked = attr.ib(type=bool)
     is_relinkable = attr.ib(type=bool)
-    invite_key = attr.ib(type=UUID)
     should_inactivate_other_customers = attr.ib(type=bool)
+    invite_key = attr.ib(type=UUID, default=None)
 
 
 @attr.s(frozen=True)
@@ -154,9 +154,9 @@ class EnterpriseCourseEnrollment:
     enterprise_customer_user = attr.ib(type=EnterpriseCustomerUser)
     course_id = attr.ib(type=CourseKey)
     saved_for_later = attr.ib(type=bool)
-    source_slug = attr.ib(type=str)
-    unenrolled = attr.ib(type=bool)
-    unenrolled_at = attr.ib(type=datetime)
+    source_slug = attr.ib(type=str, default=None)
+    unenrolled = attr.ib(type=bool, default=None)
+    unenrolled_at = attr.ib(type=datetime, default=None)
 
 
 @attr.s(frozen=True)
@@ -180,9 +180,9 @@ class BaseEnterpriseFulfillment:
     created = attr.ib(type=datetime)
     modified = attr.ib(type=datetime)
     fulfillment_type = attr.ib(type=str)
-    enterprise_course_entitlement_uuid = attr.ib(type=UUID)
-    enterprise_course_enrollment = attr.ib(type=EnterpriseCourseEnrollment)
     is_revoked = attr.ib(type=bool)
+    enterprise_course_entitlement_uuid = attr.ib(type=UUID, default=None)
+    enterprise_course_enrollment = attr.ib(type=EnterpriseCourseEnrollment, default=None)
 
 
 @attr.s(frozen=True)
@@ -197,7 +197,7 @@ class LearnerCreditEnterpriseCourseEnrollment(BaseEnterpriseFulfillment):
         transaction_id (UUID): Ledgered transaction UUID to associate with this learner credit fulfillment.
     """
 
-    transaction_id = attr.ib(type=UUID)
+    transaction_id = attr.ib(type=UUID, default=None)
 
 
 @attr.s(frozen=True)
@@ -212,4 +212,4 @@ class LicensedEnterpriseCourseEnrollment(BaseEnterpriseFulfillment):
         license_uuid (UUID): License UUID to associate with this enterprise license fulfillment.
     """
 
-    license_uuid = attr.ib(type=UUID)
+    license_uuid = attr.ib(type=UUID, default=None)

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+learner_credit_course_enrollment+revoked+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+learner_credit_course_enrollment+revoked+v1_schema.avsc
@@ -26,106 +26,134 @@
             "type": "string"
           },
           {
-            "name": "enterprise_course_entitlement_uuid",
-            "type": "string"
-          },
-          {
-            "name": "enterprise_course_enrollment",
-            "type": {
-              "name": "EnterpriseCourseEnrollment",
-              "type": "record",
-              "fields": [
-                {
-                  "name": "id",
-                  "type": "long"
-                },
-                {
-                  "name": "created",
-                  "type": "string"
-                },
-                {
-                  "name": "modified",
-                  "type": "string"
-                },
-                {
-                  "name": "enterprise_customer_user",
-                  "type": {
-                    "name": "EnterpriseCustomerUser",
-                    "type": "record",
-                    "fields": [
-                      {
-                        "name": "id",
-                        "type": "long"
-                      },
-                      {
-                        "name": "created",
-                        "type": "string"
-                      },
-                      {
-                        "name": "modified",
-                        "type": "string"
-                      },
-                      {
-                        "name": "enterprise_customer_uuid",
-                        "type": "string"
-                      },
-                      {
-                        "name": "user_id",
-                        "type": "long"
-                      },
-                      {
-                        "name": "active",
-                        "type": "boolean"
-                      },
-                      {
-                        "name": "linked",
-                        "type": "boolean"
-                      },
-                      {
-                        "name": "is_relinkable",
-                        "type": "boolean"
-                      },
-                      {
-                        "name": "invite_key",
-                        "type": "string"
-                      },
-                      {
-                        "name": "should_inactivate_other_customers",
-                        "type": "boolean"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "name": "course_id",
-                  "type": "string"
-                },
-                {
-                  "name": "saved_for_later",
-                  "type": "boolean"
-                },
-                {
-                  "name": "source_slug",
-                  "type": "string"
-                },
-                {
-                  "name": "unenrolled",
-                  "type": "boolean"
-                },
-                {
-                  "name": "unenrolled_at",
-                  "type": "string"
-                }
-              ]
-            }
-          },
-          {
             "name": "is_revoked",
             "type": "boolean"
           },
           {
+            "name": "enterprise_course_entitlement_uuid",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "enterprise_course_enrollment",
+            "type": [
+              "null",
+              {
+                "name": "EnterpriseCourseEnrollment",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "id",
+                    "type": "long"
+                  },
+                  {
+                    "name": "created",
+                    "type": "string"
+                  },
+                  {
+                    "name": "modified",
+                    "type": "string"
+                  },
+                  {
+                    "name": "enterprise_customer_user",
+                    "type": {
+                      "name": "EnterpriseCustomerUser",
+                      "type": "record",
+                      "fields": [
+                        {
+                          "name": "id",
+                          "type": "long"
+                        },
+                        {
+                          "name": "created",
+                          "type": "string"
+                        },
+                        {
+                          "name": "modified",
+                          "type": "string"
+                        },
+                        {
+                          "name": "enterprise_customer_uuid",
+                          "type": "string"
+                        },
+                        {
+                          "name": "user_id",
+                          "type": "long"
+                        },
+                        {
+                          "name": "active",
+                          "type": "boolean"
+                        },
+                        {
+                          "name": "linked",
+                          "type": "boolean"
+                        },
+                        {
+                          "name": "is_relinkable",
+                          "type": "boolean"
+                        },
+                        {
+                          "name": "should_inactivate_other_customers",
+                          "type": "boolean"
+                        },
+                        {
+                          "name": "invite_key",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "default": null
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "course_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "saved_for_later",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "source_slug",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "unenrolled",
+                    "type": [
+                      "null",
+                      "boolean"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "unenrolled_at",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  }
+                ]
+              }
+            ],
+            "default": null
+          },
+          {
             "name": "transaction_id",
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
           }
         ]
       }


### PR DESCRIPTION
This should hopefully fix the error we are currently seeing when attempting to serialize real-life LC fulfillments outside of unit test environments.  The error is exactly described in this ticket for a different event experiencing the same issue:

https://github.com/edx/edx-arch-experiments/issues/788

Basically, certain fields are passed into the serializer as None because the actual value in the database is NULL, but the serializer field default is not explicitly set to None which triggers a code path that doesn't tolerate being passed None:

https://github.com/openedx/openedx-events/blob/3170416c157df480b3d9f9f276ab7cf7b9d5e68d/openedx_events/event_bus/avro/serializer.py#L34-L44

ENT-9213