### PR TITLE
refactor: add lazy field to LibraryCollectionData

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ __________
 Changed
 ~~~~~~~
 
-* Added ``lazy`` field to ``LibraryCollectionData`` so that senders can specify if handlers can run asynchrounously.
+* Added ``background`` field to ``LibraryCollectionData`` so that senders can specify if handlers can run asynchrounously.
 
 [9.14.1] - 2024-09-17
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,14 @@ __________
 
 
 
+[9.15.0] - 2024-10-10
+---------------------
+
+Changed
+~~~~~~~
+
+* Added ``lazy`` field to ``LibraryCollectionData`` so that senders can specify if handlers can run asynchrounously.
+
 [9.14.1] - 2024-09-17
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.14.1"
+__version__ = "9.15.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -221,10 +221,10 @@ class LibraryCollectionData:
     Arguments:
         library_key (LibraryLocatorV2): a key that represents a Blockstore-based content library.
         collection_key (str): identifies the collection within the library's learning package
-        lazy (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
+        background (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
         i.e., the handler can run the task in background. By default it is False.
     """
 
     library_key = attr.ib(type=LibraryLocatorV2)
     collection_key = attr.ib(type=str)
-    lazy = attr.ib(type=bool, default=False)
+    background = attr.ib(type=bool, default=False)

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -221,7 +221,10 @@ class LibraryCollectionData:
     Arguments:
         library_key (LibraryLocatorV2): a key that represents a Blockstore-based content library.
         collection_key (str): identifies the collection within the library's learning package
+        lazy (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
+        i.e., the handler can run the task in background. By default it is False.
     """
 
     library_key = attr.ib(type=LibraryLocatorV2)
     collection_key = attr.ib(type=str)
+    lazy = attr.ib(type=bool, default=False)

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+created+v1_schema.avsc
@@ -16,6 +16,10 @@
           {
             "name": "collection_key",
             "type": "string"
+          },
+          {
+            "name": "lazy",
+            "type": "boolean"
           }
         ]
       }

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+created+v1_schema.avsc
@@ -18,7 +18,7 @@
             "type": "string"
           },
           {
-            "name": "lazy",
+            "name": "background",
             "type": "boolean"
           }
         ]

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+deleted+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+deleted+v1_schema.avsc
@@ -16,6 +16,10 @@
           {
             "name": "collection_key",
             "type": "string"
+          },
+          {
+            "name": "lazy",
+            "type": "boolean"
           }
         ]
       }

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+deleted+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+deleted+v1_schema.avsc
@@ -18,7 +18,7 @@
             "type": "string"
           },
           {
-            "name": "lazy",
+            "name": "background",
             "type": "boolean"
           }
         ]

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+updated+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+updated+v1_schema.avsc
@@ -16,6 +16,10 @@
           {
             "name": "collection_key",
             "type": "string"
+          },
+          {
+            "name": "lazy",
+            "type": "boolean"
           }
         ]
       }

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+updated+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+updated+v1_schema.avsc
@@ -18,7 +18,7 @@
             "type": "string"
           },
           {
-            "name": "lazy",
+            "name": "background",
             "type": "boolean"
           }
         ]


### PR DESCRIPTION
This is required to handle the signal asynchronously whenever the sender does not care about the handler execution completion.

For example, whenever multiple collections are updated due to a component being added or removed, we do not want to wait for all collection update handlers to complete.

**Dependencies:**

* https://github.com/openedx/edx-platform/pull/35600
* https://github.com/openedx/openedx-learning/pull/238
* https://github.com/openedx/frontend-app-authoring/pull/1373

**Merge deadline:** ASAP

**Testing instructions:**

* See https://github.com/openedx/frontend-app-authoring/pull/1373 for test instructions.


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)