### PR TITLE
docs: change ADRs status over a year old to accepted

### DIFF
--- a/docs/decisions/0004-external-event-bus-and-django-signal-events.rst
+++ b/docs/decisions/0004-external-event-bus-and-django-signal-events.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Provisional
+Accepted
 
 Context
 -------

--- a/docs/decisions/0006-event-schema-serialization-and-evolution.rst
+++ b/docs/decisions/0006-event-schema-serialization-and-evolution.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Provisional
+Accepted
 
 Context
 -------

--- a/docs/decisions/0008-signals-with-pii.rst
+++ b/docs/decisions/0008-signals-with-pii.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Provisional
+Accepted
 
 Context
 -------

--- a/docs/decisions/0013-special-exam-submission-and-review-events.rst
+++ b/docs/decisions/0013-special-exam-submission-and-review-events.rst
@@ -4,7 +4,7 @@
 Status
 ******
 
-**Draft** 2023-10-02
+**Accepted** 2023-10-02
 
 Context
 *******


### PR DESCRIPTION
## Description

This PR updates ADRs statuses from non-accepted status to accepted, assuming the decisions were already implemented.