### PR TITLE
docs: update adding events how-to to use new config style

### DIFF
--- a/docs/how-tos/adding-events-to-event-bus.rst
+++ b/docs/how-tos/adding-events-to-event-bus.rst
@@ -21,21 +21,22 @@ In the producing/host application, include ``openedx_events`` in ``INSTALLED_APP
 
    # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
    # .. setting_default: {}
-   # .. setting_description: Dictionary of event_types mapped to lists of dictionaries containing topic related configuration.
-   #    Each topic configuration dictionary contains
-   #    * a topic/stream name called `topic` where the event will be pushed to.
-   #    * a flag called `enabled` denoting whether the event will be published to the topic.
-   #    * `event_key_field` which is a period-delimited string path to event data field to use as event key.
+   # .. setting_description: Dictionary of event_types to dictionaries for topic related configuration.
+   #    Each topic configuration dictionary uses the topic as a key and contains a flag called `enabled`
+   #    denoting whether the event will be and `event_key_field` which is a period-delimited string path
+   #    to event data field to use as event key.
    #    Note: The topic names should not include environment prefix as it will be dynamically added based on
    #    EVENT_BUS_TOPIC_PREFIX setting.
    EVENT_BUS_PRODUCER_CONFIG = {
-       'org.openedx.content_authoring.xblock.published.v1': [
-           {'topic': 'content-authoring-xblock-lifecycle', 'event_key_field': 'xblock_info.usage_key', 'enabled': True},
-           {'topic': 'content-authoring-xblock-published', 'event_key_field': 'xblock_info.usage_key', 'enabled': True},
-       ],
-       'org.openedx.content_authoring.xblock.deleted.v1': [
-           {'topic': 'content-authoring-xblock-lifecycle', 'event_key_field': 'xblock_info.usage_key', 'enabled': True},
-       ],
+       'org.openedx.content_authoring.xblock.published.v1': {
+           'content-authoring-xblock-lifecycle': {'event_key_field': 'xblock_info.usage_key', 'enabled': True},
+           'content-authoring-xblock-published': {'event_key_field': 'xblock_info.usage_key', 'enabled': True}
+       },
+       'org.openedx.content_authoring.xblock.deleted.v1': {
+           'content-authoring-xblock-lifecycle': {'event_key_field': 'xblock_info.usage_key', 'enabled': True},
+       },
    }
 
-The ``EVENT_BUS_PRODUCER_CONFIG`` is read by openedx_events and a handler is attached which does the leg work of reading the configuration again and pushing to appropriate handlers.
+The ``EVENT_BUS_PRODUCER_CONFIG`` is read by openedx_events and a handler is
+attached which does the leg work of reading the configuration again and pushing
+to appropriate handlers.

--- a/docs/how-tos/adding-events-to-event-bus.rst
+++ b/docs/how-tos/adding-events-to-event-bus.rst
@@ -21,10 +21,10 @@ In the producing/host application, include ``openedx_events`` in ``INSTALLED_APP
 
    # .. setting_name: EVENT_BUS_PRODUCER_CONFIG
    # .. setting_default: {}
-   # .. setting_description: Dictionary of event_types to dictionaries for topic related configuration.
-   #    Each topic configuration dictionary uses the topic as a key and contains a flag called `enabled`
-   #    denoting whether the event will be and `event_key_field` which is a period-delimited string path
-   #    to event data field to use as event key.
+   # .. setting_description: Dictionary of event_types to dictionaries for topic-related configuration.
+   #    Each topic configuration dictionary uses the topic as a key and contains:
+   #    * A flag called `enabled` denoting whether the event will be published.
+   #    * The `event_key_field` which is a period-delimited string path to event data field to use as event key.
    #    Note: The topic names should not include environment prefix as it will be dynamically added based on
    #    EVENT_BUS_TOPIC_PREFIX setting.
    EVENT_BUS_PRODUCER_CONFIG = {


### PR DESCRIPTION
**Description:** Updates how-doc to reflect changes from [ADR: 114](https://github.com/open-craft/openedx-events/blob/6f04b4b0d7f0d2c800ec5044e98e708a52c447b8/docs/decisions/0014-new-event-bus-producer-config.rst#L58)

**ISSUE:** N/A

**Dependencies:** None

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
