### PR TITLE
docs: [FC-0074] replace warning text with event_warning annotation

### DIFF
--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -104,7 +104,7 @@ XBLOCK_DUPLICATED = OpenEdxPublicSignal(
 # .. event_type: org.openedx.content_authoring.course.certificate_config.changed.v1
 # .. event_name: COURSE_CERTIFICATE_CONFIG_CHANGED
 # .. event_description: Fired when a course certificate configuration changes in Studio.
-#      Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 # .. event_data: CertificateConfigData
 COURSE_CERTIFICATE_CONFIG_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.course.certificate_config.changed.v1",
@@ -116,7 +116,7 @@ COURSE_CERTIFICATE_CONFIG_CHANGED = OpenEdxPublicSignal(
 # .. event_type: org.openedx.content_authoring.course.certificate_config.deleted.v1
 # .. event_name: COURSE_CERTIFICATE_CONFIG_DELETED
 # .. event_description: Fired when a course certificate configuration deletes in Studio.
-#      Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 # .. event_data: CertificateConfigData
 COURSE_CERTIFICATE_CONFIG_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.course.certificate_config.deleted.v1",

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -167,7 +167,7 @@ COHORT_MEMBERSHIP_CHANGED = OpenEdxPublicSignal(
 # .. event_type: org.openedx.learning.discussions.configuration.changed.v1
 # .. event_name: COURSE_DISCUSSIONS_CHANGED
 # .. event_description: emitted when the configuration for a course's discussions changes in the course
-#       Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 # .. event_data: CourseDiscussionConfigurationData
 COURSE_DISCUSSIONS_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.discussions.configuration.changed.v1",
@@ -204,8 +204,7 @@ XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
 # .. event_name: USER_NOTIFICATION_REQUESTED
 # .. event_description: Can be fired from apps to send user notifications.
 # .. event_data: UserNotificationSendListData
-# Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
-#
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 USER_NOTIFICATION_REQUESTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.user.notification.requested.v1",
     data={
@@ -296,7 +295,7 @@ COURSE_ACCESS_ROLE_REMOVED = OpenEdxPublicSignal(
 # .. event_name: FORUM_THREAD_CREATED
 # .. event_description: Emitted when a new thread is created in a discussion
 # .. event_data: DiscussionThreadData
-#       Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 FORUM_THREAD_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.thread.created.v1",
     data={
@@ -308,7 +307,7 @@ FORUM_THREAD_CREATED = OpenEdxPublicSignal(
 # .. event_name: FORUM_THREAD_RESPONSE_CREATED
 # .. event_description: Emitted when a new response is added to a thread
 # .. event_data: DiscussionThreadData
-#        Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+#  .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 FORUM_THREAD_RESPONSE_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.response.created.v1",
     data={
@@ -320,7 +319,7 @@ FORUM_THREAD_RESPONSE_CREATED = OpenEdxPublicSignal(
 # .. event_name: FORUM_RESPONSE_COMMENT_CREATED
 # .. event_description: Emitted when a new comment is added to a response
 # .. event_data: DiscussionThreadData
-#       Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 FORUM_RESPONSE_COMMENT_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.response.created.v1",
     data={
@@ -333,8 +332,7 @@ FORUM_RESPONSE_COMMENT_CREATED = OpenEdxPublicSignal(
 # .. event_name: COURSE_NOTIFICATION_REQUESTED
 # .. event_description: Emitted when a notification is requested for a course
 # .. event_data: CourseNotificationData
-# Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
-#
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 COURSE_NOTIFICATION_REQUESTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.notification.requested.v1",
     data={
@@ -347,7 +345,7 @@ COURSE_NOTIFICATION_REQUESTED = OpenEdxPublicSignal(
 # .. event_name: ORA_SUBMISSION_CREATED
 # .. event_description: Emitted when a new ORA submission is created
 # .. event_data: ORASubmissionData
-# Warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
+# .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 ORA_SUBMISSION_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.ora.submission.created.v1",
     data={

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ pynacl==1.5.0
     # via edx-django-utils
 six==1.17.0
     # via edx-ccx-keys
-sqlparse==0.5.2
+sqlparse==0.5.3
     # via django
 stevedore==5.4.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,7 +59,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==1.7.0
+code-annotations @ git+https://github.com/eduNEXT/code-annotations.git@MJG/event-warning
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -342,7 +342,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-sqlparse==0.5.2
+sqlparse==0.5.3
     # via
     #   -r requirements/quality.txt
     #   django

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -43,7 +43,7 @@ click==8.1.7
     #   code-annotations
     #   edx-django-utils
     #   uvicorn
-code-annotations==1.7.0
+code-annotations @ git+https://github.com/eduNEXT/code-annotations.git@MJG/event-warning
     # via -r requirements/test.txt
 colorama==0.4.6
     # via sphinx-autobuild
@@ -263,7 +263,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.2
+sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -294,7 +294,7 @@ urllib3==2.2.3
     #   twine
 uvicorn==0.32.1
     # via sphinx-autobuild
-watchfiles==1.0.0
+watchfiles==1.0.3
     # via sphinx-autobuild
 websockets==14.1
     # via sphinx-autobuild

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -35,7 +35,7 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.7.0
+code-annotations @ git+https://github.com/eduNEXT/code-annotations.git@MJG/event-warning
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -225,7 +225,7 @@ six==1.17.0
     #   edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.5.2
+sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,4 +6,4 @@
 ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
-code-annotations==1.7.0
+git+https://github.com/eduNEXT/code-annotations.git@MJG/event-warning

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ click==8.1.7
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
-code-annotations==1.7.0
+code-annotations @ git+https://github.com/eduNEXT/code-annotations.git@MJG/event-warning
     # via -r requirements/test.in
 coverage[toml]==7.6.9
     # via pytest-cov
@@ -103,7 +103,7 @@ six==1.17.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
-sqlparse==0.5.2
+sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django


### PR DESCRIPTION
## Description

Use `.. event_warning` annotation to indicate a critical characteristic of an event. As for now, these warnings have been used to warn users about missing event bus capabilities.

## Testing Instructions
1. Create a venv 
2. Install this version of openedx-events which uses `.. event_warning` instead of a `Warning: ` label.
3. Generate docs for openedx-events by running: `make docs`

Here's the expected output:
![image](https://github.com/user-attachments/assets/5f9aed6b-eeef-4aee-bcdb-2aa2db698b96)

This PR depends on https://github.com/openedx/code-annotations/pull/136