### PR TITLE
docs: [FC-0074] add documentation for in-line code annotations

### DIFF
--- a/docs/how-tos/creating-new-events.rst
+++ b/docs/how-tos/creating-new-events.rst
@@ -111,25 +111,13 @@ specifies:
 
 The definition created in this step must comply with:
 
-- It should be created in the `signals.py` file in the corresponding subdomain. Refer to Naming Conventions ADR for more
+- It should be created in the ``signals.py`` file in the corresponding subdomain. Refer to Naming Conventions ADR for more
   on events subdomains.
-- It should follow the naming conventions specified in Naming Conventions ADR.
-- It must be documented using in-line documentation with at least: `event_type`, `event_name`, `event_description` and
-  `event_data`:
+- It should follow the naming conventions specified in :doc:`../decisions/0002-events-naming-and-versioning`.
+- It must be documented using in-line documentation with at least: ``event_type``, ``event_name``, ``event_description`` and
+  ``event_data``. See :doc:`../reference/in-line-code-annotations-for-an-event` for more information.
 
-+-------------------+----------------------------------------------------------------------------------------------------+
-| Annotation        | Description                                                                                        |
-+===================+====================================================================================================+
-| event_type        | Identifier across services of the event. Should follow the events naming conventions.              |
-+-------------------+----------------------------------------------------------------------------------------------------+
-| event_name        | Name of the variable storing the event instance.                                                   |
-+-------------------+----------------------------------------------------------------------------------------------------+
-| event_description | General description which includes when the event should be emitted.                               |
-+-------------------+----------------------------------------------------------------------------------------------------+
-| event_data        | What type of class attribute the event sends.                                                      |
-+-------------------+----------------------------------------------------------------------------------------------------+
-
-Consider the following example:
+Consider the course enrollment created event as an example:
 
 .. code-block:: python
 

--- a/docs/reference/in-line-code-annotations-for-an-event.rst
+++ b/docs/reference/in-line-code-annotations-for-an-event.rst
@@ -1,0 +1,34 @@
+In-line Code Annotations for An Open edX Event
+==============================================
+
+When creating a new Open edX Event, you must document the event definition using in-line code annotations. These annotations provide a structured way to document the event's metadata, making it easier for developers to understand the event's purpose and how it should be used.
+
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+| Annotation                       | Description                                                                                                                      |
++==================================+==================================================================================================================================+
+| event_type (Required)            | Identifier across services of the event. Should follow the :doc:`../decisions/0002-events-naming-and-versioning` standard.       |
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+| event_name (Required)            | Name of the variable storing the event instance.                                                                                 |
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+| event_description (Required)     | General description which includes when the event should be emitted.                                                             |
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+| event_data (Required)            | What type of class attribute the event sends.                                                                                    |
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+| event_warnings (Optional)        | Any warnings or considerations that should be taken into account when using the event.                                           |
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+
+Consider the following example:
+
+.. code-block:: python
+
+    # Location openedx_events/learning/signals.py
+    # .. event_type: org.openedx.learning.course.enrollment.created.v1
+    # .. event_name: COURSE_ENROLLMENT_CREATED
+    # .. event_description: emitted when the user's enrollment process is completed.
+    # .. event_data: CourseEnrollmentData
+    COURSE_ENROLLMENT_CREATED = OpenEdxPublicSignal(
+        event_type="org.openedx.learning.course.enrollment.created.v1",
+        data={
+            "enrollment": CourseEnrollmentData,
+        }
+    )

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,6 +6,7 @@ References
    :caption: Contents:
 
    events
+   in-line-code-annotations-for-an-event
    glossary
    event-bus-configurations
    oeps


### PR DESCRIPTION
## Description

To improve visibility, this PR moves the in-line code annotation docs for events from a how-to to the reference category. 

## Supporting information

This comment addresses this comment: https://github.com/openedx/code-annotations/pull/136#discussion_r1880131463. Once we merge it and make it available, we should reference this new document here https://github.com/openedx/code-annotations/blob/master/code_annotations/contrib/config/openedx_events_annotations.yaml#L9.

## Testing instructions

You can see the docs when generated here: https://docsopenedxorg--432.org.readthedocs.build/projects/openedx-events/en/432/reference/in-line-code-annotations-for-an-event.html

## Deadline

None

## Other information

NA

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Code dependencies reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
