### PR TITLE
fix: use correct event type for forum events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,13 @@ Unreleased
 __________
 
 
+[9.15.1] - 2024-12-20
+---------------------
+
+Changed
+~~~~~~~
+
+* Fixed ``event_type`` field in ``FORUM_THREAD_CREATED``, ``FORUM_THREAD_RESPONSE_CREATED``, and ``FORUM_RESPONSE_COMMENT_CREATED`` events in learning.
 
 [9.15.0] - 2024-10-10
 ---------------------

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.15.0"
+__version__ = "9.15.1"

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -297,7 +297,7 @@ COURSE_ACCESS_ROLE_REMOVED = OpenEdxPublicSignal(
 # .. event_data: DiscussionThreadData
 # .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 FORUM_THREAD_CREATED = OpenEdxPublicSignal(
-    event_type="org.openedx.learning.thread.created.v1",
+    event_type="org.openedx.learning.forum.thread.created.v1",
     data={
         "thread": DiscussionThreadData,
     }
@@ -309,7 +309,7 @@ FORUM_THREAD_CREATED = OpenEdxPublicSignal(
 # .. event_data: DiscussionThreadData
 #  .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 FORUM_THREAD_RESPONSE_CREATED = OpenEdxPublicSignal(
-    event_type="org.openedx.learning.response.created.v1",
+    event_type="org.openedx.learning.forum.thread.response.created.v1",
     data={
         "thread": DiscussionThreadData,
     }
@@ -321,7 +321,7 @@ FORUM_THREAD_RESPONSE_CREATED = OpenEdxPublicSignal(
 # .. event_data: DiscussionThreadData
 # .. event_warning: This event is currently incompatible with the event bus, list/dict cannot be serialized yet
 FORUM_RESPONSE_COMMENT_CREATED = OpenEdxPublicSignal(
-    event_type="org.openedx.learning.response.created.v1",
+    event_type="org.openedx.learning.forum.thread.response.comment.created.v1",
     data={
         "thread": DiscussionThreadData,
     }

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -24,9 +24,9 @@ KNOWN_UNSERIALIZABLE_SIGNALS = [
     "org.openedx.content_authoring.course.certificate_config.changed.v1",
     "org.openedx.content_authoring.course.certificate_config.deleted.v1",
     "org.openedx.learning.user.notification.requested.v1",
-    "org.openedx.learning.thread.created.v1",
-    "org.openedx.learning.response.created.v1",
-    "org.openedx.learning.comment.created.v1",
+    "org.openedx.learning.forum.thread.created.v1",
+    "org.openedx.learning.forum.thread.response.created.v1",
+    "org.openedx.learning.forum.thread.response.comment.created.v1",
     "org.openedx.learning.course.notification.requested.v1",
     "org.openedx.learning.ora.submission.created.v1",
 ]


### PR DESCRIPTION
<!--

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

Fore more details on the Hooks Extension Framework contribution process, see:

https://docs.openedx.org/en/latest/developers/concepts/hooks_extension_framework.html

-->

## Description

This PR fixes the forum IDs so:
1. They match each event definition. 
2. They're unique.

This change shouldn't be considered a breaking change since these events are not being sent to the event bus yet, so the `event_type` is not actively used by consumers.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added with short description of the change and current date
- [x] Documentation updated (not only docstrings)
- [x] ~Code dependencies reviewed~ NA
- [ ] Fixup commits are squashed away
- [x] ~Unit tests added/updated~ NA
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
