### PR TITLE
docs: update edx.rtd links to docs.openedx.org

### DIFF
--- a/docs/concepts/openedx-events.rst
+++ b/docs/concepts/openedx-events.rst
@@ -86,8 +86,8 @@ For more information on using Open edX Events, refer to the :doc:`../how-tos/cre
 .. _triggering the COURSE_ENROLLMENT_CREATED event: https://github.com/openedx/edx-platform/blob/master/common/djangoapps/student/models/course_enrollment.py#L777-L795
 .. _course_enrollment_post_save receiver: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/notifications/handlers.py#L38-L53
 .. _Django signals registry mechanism: https://docs.djangoproject.com/en/4.2/topics/signals/#listening-to-signals
-.. _signal receivers in their plugins: https://edx.readthedocs.io/projects/edx-django-utils/en/latest/edx_django_utils.plugins.html#edx_django_utils.plugins.constants.PluginSignals
-.. _Open edX Django plugins: https://edx.readthedocs.io/projects/edx-django-utils/en/latest/plugins/readme.html
+.. _signal receivers in their plugins: https://docs.openedx.org/projects/edx-django-utils/en/latest/edx_django_utils.plugins.html#edx_django_utils.plugins.constants.PluginSignals
+.. _Open edX Django plugins: https://docs.openedx.org/projects/edx-django-utils/en/latest/plugins/readme.html
 .. _OpenEdxPublicSignal: https://github.com/openedx/openedx-events/blob/main/openedx_events/tooling.py#L37
 .. _Django's Signals class: https://docs.djangoproject.com/en/4.2/topics/signals/#defining-and-sending-signals
 .. _send_event: https://github.com/openedx/openedx-events/blob/main/openedx_events/tooling.py#L185

--- a/openedx_events/analytics/data.py
+++ b/openedx_events/analytics/data.py
@@ -21,7 +21,7 @@ class TrackingLogData:
         data (str): json string representation of a dictionary with extra data (optional), e.g.,
            >>> {"course_id": "course-v1:edX+DemoX+Demo_Course"}
         context (dict): json string representation of a dictionary of context data
-           defined in https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/
+           defined in https://docs.openedx.org/en/latest/developers/references/internal_data_formats/index.html
     """
 
     name = attr.ib(type=str)


### PR DESCRIPTION
We migrated the django-utils docs to docs.openedx.org so update the URLs
