### PR TITLE
feat: Raise exception when consume_indefinitely called without config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Change Log
 Unreleased
 __________
 
+[9.19.0] - 2025-03-14
+---------------------
+
+Changed
+~~~~~~~
+
+* When ``EVENT_BUS_CONSUMER`` setting is missing or unusable, calling ``consume_indefinitely`` will raise an exception instead of silently exiting.
+
 [9.18.2] - 2025-02-18
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.18.2"
+__version__ = "9.19.0"

--- a/openedx_events/event_bus/__init__.py
+++ b/openedx_events/event_bus/__init__.py
@@ -145,7 +145,10 @@ class NoEventBusConsumer(EventBusConsumer):
     """
 
     def consume_indefinitely(self) -> None:
-        """Do nothing."""
+        """
+        Raise an error, because we tried to consume events but nothing was configured.
+        """
+        raise Exception("Cannot consume events; no consumer configured.")
 
 
 # .. setting_name: EVENT_BUS_CONSUMER

--- a/openedx_events/event_bus/tests/test_loader.py
+++ b/openedx_events/event_bus/tests/test_loader.py
@@ -3,6 +3,7 @@ Tests for event bus implementation loader.
 """
 
 import copy
+import re
 import sys
 import warnings
 from contextlib import contextmanager
@@ -137,11 +138,11 @@ class TestConsumer(TestCase):
         """
         Test that the default is of the right class but does nothing.
         """
-        consumer = make_single_consumer(topic="test", group_id="test", signal=SESSION_LOGIN_COMPLETED)
+        with assert_warnings(["Event Bus setting EVENT_BUS_CONSUMER is missing; component will be inactive"]):
+            consumer = make_single_consumer(topic="test", group_id="test", signal=SESSION_LOGIN_COMPLETED)
 
-        with assert_warnings([]):
-            # Nothing thrown, no warnings.
-            assert consumer.consume_indefinitely() is None
+        with pytest.raises(Exception, match=re.escape("Cannot consume events; no consumer configured.")):
+            consumer.consume_indefinitely()
 
 
 class TestSettings(TestCase):


### PR DESCRIPTION
## Description

It's misleading to have the management command exit immediately with exit code 0 when the config is missing. It's also a little harder than it should be to debug this scenario because at most you get a warning log message (which is easy to miss). A stack trace and error exit should be clearer.

## Deadline

None

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [x] All reviewers approved
- [x] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added with short description of the change and current date
- [x] Documentation updated (not only docstrings)
- [x] Integration with other services reviewed
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
