### PR TITLE
FC-73 Add EXTERNAL_GRADER_SCORE_SUBMITTED signal to broadcast scoring events (Feature: Add event emission for external grader scores)

### DIFF
--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -227,3 +227,33 @@ class LibraryCollectionData:
     library_key = attr.ib(type=LibraryLocatorV2)
     collection_key = attr.ib(type=str)
     background = attr.ib(type=bool, default=False)
+
+
+@attr.s(frozen=True)
+class ExternalGraderScoreData:
+    """
+    Class that encapsulates score data provided by an external grader.
+
+    This class uses attr.s with frozen=True to create an immutable structure
+    containing information about the score assigned to a student submission.
+
+    Attributes:
+        points_possible (int): Maximum possible score for this assignment
+        points_earned (int): Score earned by the student
+        course_id (str): Unique identifier for the course
+        score_msg (str): Descriptive message about the score (feedback)
+        submission_id (int): Unique identifier for the graded submission
+        user_id (str): ID of the user who submitted the assignment
+        module_id (str): ID of the module/problem being graded
+        queue_key (str): Unique key for the submission in the queue
+        queue_name (str): Name of the queue that processed the submission
+    """
+    points_possible = attr.ib(type=int)
+    points_earned = attr.ib(type=int)
+    course_id = attr.ib(type=str)
+    score_msg = attr.ib(type=str)
+    submission_id = attr.ib(type=int)
+    user_id = attr.ib(type=str)
+    module_id = attr.ib(type=str)
+    queue_key = attr.ib(type=str)
+    queue_name = attr.ib(type=str)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -19,6 +19,7 @@ from openedx_events.content_authoring.data import (
     LibraryCollectionData,
     XBlockData,
 )
+from openedx_events.content_authoring.data import ExternalGraderScoreData
 from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.content_authoring.course.catalog_info.changed.v1
@@ -287,5 +288,16 @@ COURSE_IMPORT_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.course.import.completed.v1",
     data={
         "course": CourseData,
+    }
+)
+
+# .. event_type: org.openedx.learning.external_grader.score.submitted.v1
+# .. event_name: EXTERNAL_GRADER_SCORE_SUBMITTED
+# .. event_description: emitted when an external grader provides a score for a submission
+# .. event_data: ExternalGraderScoreData
+EXTERNAL_GRADER_SCORE_SUBMITTED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.external_grader.score.submitted.v1",
+    data={
+        "score": ExternalGraderScoreData,
     }
 )


### PR DESCRIPTION
# FC-73 Feature: Add event emission for external grader scores

⚠️ **Important:** This PR builds on the `ExternalGraderDetail`, `SubmissionFile` infrastructure, and the `XQueueViewSet` deployed in previous PRs (FC-73). Please ensure those changes are fully deployed before merging.

## Description

This PR adds event emission to notify when an external grader submits a score result. When a grader submits a result and the score is successfully saved, the system now emits an event with all necessary information for the LMS to render the graded XBlock.

The implementation leverages the existing external grading workflow in the `XQueueViewSet` and adds a signaling layer through the `EXTERNAL_GRADER_SCORE_SUBMITTED` event. This change is essential to enable the gradual migration from HTTP-based callbacks (XQueue) to an event-driven approach.

Key changes:
- Add `queue_key` field to the `ExternalGraderDetail` model to identify the source queue
- Include `queue_key` in the `create_external_grader_detail` method
- Emit the `EXTERNAL_GRADER_SCORE_SUBMITTED` event after successful score update
- Add migration for the new `queue_key` field

## Supporting information

This PR is part of the migration from the XQueue system to an event-based architecture for external grading. It builds upon changes implemented in previous PRs in the FC-73 project that have already established:
- The `ExternalGraderDetail` model for storing external grading details
- The `XQueueViewSet` to provide compatible endpoints for external graders

## Testing instructions

1. Set up an environment with edx-submissions and external grading models
2. Verify that the `EXTERNAL_GRADER_SCORE_SUBMITTED` event is correctly emitted when:
   - A POST request is made to the `put_result` endpoint
   - The result is validated correctly
   - The score is successfully saved

3. Check that the event contains all required fields

4. Verify that log entries correctly reflect event emission

## Deadline

None

## Other information

This PR completes the event emission architecture for the external grading workflow. With this implementation, event consumers in the LMS can now react to scores submitted by external graders without relying on HTTP callbacks.

### Dependencies

This PR directly depends on previous PRs in the FC-73 series that implemented:
- The `ExternalGraderDetail` and `SubmissionFile` models
- The `XQueueViewSet` with its endpoints for interaction with external graders
