### PR TITLE
FC-73 Add EXTERNAL_GRADER_SCORE_SUBMITTED signal to broadcast scoring events ( Feature: Add external grader score data model and signal))

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Change Log
 Unreleased
 __________
 
+[10.1.0] - 2024-05-01
+---------------------
+
+Added
+~~~~~
+
+* Added new ``EXTERNAL_GRADER_SCORE_SUBMITTED`` event in learning.
+* Add ``ExternalGraderScoreData`` to support this event
+
 [10.0.0] - 2024-04-04
 ---------------------
 Changed

--- a/docs/decisions/0017-event-signal-for-external-grader-score-submission.rst
+++ b/docs/decisions/0017-event-signal-for-external-grader-score-submission.rst
@@ -1,0 +1,116 @@
+17. Event Signal for External Grader Score Submission
+#####################################################
+
+Status
+******
+
+**Provisional** *2025-03-18*
+
+Implemented by: https://github.com/openedx/openedx-events/pull/482
+
+Context
+*******
+
+The Open edX platform is currently undergoing a migration from the traditional XQueue system to a more modern event-driven architecture for processing external grader submissions. As part of this transition, we need a standardized way to communicate scoring events between services.
+
+Currently, the communication between external graders and the LMS relies on HTTP callbacks, which:
+
+1. Creates tight coupling between services
+2. Introduces potential points of failure through network dependencies
+3. Makes asynchronous processing difficult
+4. Complicates system monitoring and debugging
+
+An event-based approach would resolve these issues by providing a standardized, decoupled communication mechanism between components involved in the external grading workflow.
+
+Decision
+********
+
+We will add a new event signal to the openedx-events repository to standardize the communication of external grader score submissions. This event will be triggered in the edx-submissions repository's when a score is received:
+
+1. **Create ExternalGraderScoreData Class**:
+   - Define an immutable data structure using ``attr.s(frozen=True)``
+   - Include all necessary fields for score processing: points_earned, points_possible, course_id, etc.
+   - Ensure proper typing for validation
+
+2. **Implement EXTERNAL_GRADER_SCORE_SUBMITTED Signal**:
+   - Define event type following Open edX naming conventions
+   - Use the standard OpenEdxPublicSignal implementation
+   - Include appropriate metadata and documentation
+   - Ensure the signal carries the ExternalGraderScoreData
+
+3. **Event Trigger Points**:
+   - This event will be triggered in edx-submissions when a score is received
+   - Specifically, it will be emitted in the submissions put_result service after the score has been successfully recorded in the database
+   - The primary trigger location will be in the views/xqueue.py module's save_score function
+
+4. **Event Receiver**:
+   - The event will be received in the LMS using a signal receiver decorator
+   - The receiver function `handle_external_grader_score` will update the corresponding XBlock
+   - This receiver will replace the HTTP callback mechanism previously used with Xqueue
+
+Implementation:
+
+.. code-block:: python
+
+   @attr.s(frozen=True)
+   class ExternalGraderScoreData:
+       """
+       Class that encapsulates score data provided by an external grader.
+
+       This class uses attr.s with frozen=True to create an immutable structure
+       containing information about the score assigned to a student submission.
+
+       Attributes:
+           points_possible (int): Maximum possible score for this assignment
+           points_earned (int): Score earned by the student
+           course_id (str): Unique identifier for the course
+           score_msg (str): Descriptive message about the score (feedback)
+           submission_id (int): Unique identifier for the graded submission
+           user_id (str): ID of the user who submitted the assignment
+           module_id (str): ID of the module/problem being graded
+           queue_key (str): Unique key for the submission in the queue
+           queue_name (str): Name of the queue that processed the submission
+       """
+
+       points_possible = attr.ib(type=int)
+       points_earned = attr.ib(type=int)
+       course_id = attr.ib(type=str)
+       score_msg = attr.ib(type=str)
+       submission_id = attr.ib(type=int)
+       user_id = attr.ib(type=str)
+       module_id = attr.ib(type=str)
+       queue_key = attr.ib(type=str)
+       queue_name = attr.ib(type=str)
+
+   # .. event_type: org.openedx.content_authoring.external_grader.score.submitted.v1
+   # .. event_name: EXTERNAL_GRADER_SCORE_SUBMITTED
+   # .. event_description: emitted when an external grader provides a score for a submission
+   # .. event_data: ExternalGraderScoreData
+   EXTERNAL_GRADER_SCORE_SUBMITTED = OpenEdxPublicSignal(
+       event_type="org.openedx.content_authoring.external_grader.score.submitted.v1",
+       data={
+           "score_data": ExternalGraderScoreData,
+       }
+   )
+
+Consequences
+************
+
+This event signal provides a standardized way for communicating external grader scores across Open edX services. It supports the transition from HTTP-based callbacks to a more robust event-driven architecture.
+
+The primary benefits include decoupled services, standardized communication, and support for asynchronous processing. The main consideration is ensuring coordination between services during implementation.
+
+References
+**********
+
+Related Repositories:
+
+* openedx-events: https://github.com/openedx/openedx-events
+* edx-submissions: https://github.com/openedx/edx-submissions
+* edx-platform: https://github.com/openedx/edx-platform
+* edx-submissions event implement in PR: https://github.com/openedx/edx-submissions/pull/292
+
+Documentation:
+
+* Open edX Events Framework Documentation: https://github.com/openedx/openedx-events/blob/master/README.rst
+* XQueue Migration Plan: https://github.com/openedx/edx-platform/pull/36258

--- a/docs/decisions/index.rst
+++ b/docs/decisions/index.rst
@@ -21,3 +21,4 @@ Architectural Decision Records (ADRs)
    0014-new-event-bus-producer-config
    0015-outbox-pattern-and-production-modes
    0016-event-design-practices
+   0017-event-signal-for-external-grader-score-submission

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "10.0.0"
+__version__ = "10.1.0"

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -625,3 +625,34 @@ class VerificationAttemptData:
     status = attr.ib(type=str)
     name = attr.ib(type=str, default=None)
     expiration_date = attr.ib(type=datetime, default=None)
+
+
+@attr.s(frozen=True)
+class ExternalGraderScoreData:
+    """
+    Class that encapsulates score data provided by an external grader.
+
+    This class uses attr.s with frozen=True to create an immutable structure
+    containing information about the score assigned to a student submission.
+
+    Attributes:
+        points_possible (int): Maximum possible score for this assignment
+        points_earned (int): Score earned by the student
+        course_id (str): Unique identifier for the course
+        score_msg (str): Descriptive message about the score (feedback)
+        submission_id (int): Unique identifier for the graded submission
+        user_id (str): ID of the user who submitted the assignment
+        module_id (str): ID of the module/problem being graded
+        queue_key (str): Unique key for the submission in the queue
+        queue_name (str): Name of the queue that processed the submission
+    """
+
+    points_possible = attr.ib(type=int)
+    points_earned = attr.ib(type=int)
+    course_id = attr.ib(type=str)
+    score_msg = attr.ib(type=str)
+    submission_id = attr.ib(type=int)
+    user_id = attr.ib(type=str)
+    module_id = attr.ib(type=str)
+    queue_key = attr.ib(type=str)
+    queue_name = attr.ib(type=str)

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -20,6 +20,7 @@ from openedx_events.learning.data import (
     CoursePassingStatusData,
     DiscussionThreadData,
     ExamAttemptData,
+    ExternalGraderScoreData,
     ORASubmissionData,
     PersistentCourseGradeData,
     ProgramCertificateData,
@@ -489,5 +490,17 @@ IDV_ATTEMPT_DENIED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.idv_attempt.denied.v1",
     data={
         "idv_attempt": VerificationAttemptData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.external_grader.score.submitted.v1
+# .. event_name: EXTERNAL_GRADER_SCORE_SUBMITTED
+# .. event_description: emitted when an external grader provides a score for a submission
+# .. event_data: ExternalGraderScoreData
+EXTERNAL_GRADER_SCORE_SUBMITTED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.external_grader.score.submitted.v1",
+    data={
+        "score": ExternalGraderScoreData,
     }
 )

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -29,6 +29,7 @@ KNOWN_UNSERIALIZABLE_SIGNALS = [
     "org.openedx.learning.forum.thread.response.comment.created.v1",
     "org.openedx.learning.course.notification.requested.v1",
     "org.openedx.learning.ora.submission.created.v1",
+    "org.openedx.learning.external_grader.score.submitted.v1",
 ]
 
 SIGNAL_PROCESSED_FROM_EVENT_BUS = "from_event_bus"


### PR DESCRIPTION
# FC-73 Feature: Add external grader score data model and signal

## Description

This PR introduces the foundation for an event-based external grader score submission system. It establishes the core components needed to transition from the HTTP-based XQueue callback architecture to an event-driven approach for updating XBlocks with scoring data.

Key components added:
- `ExternalGraderScoreData` class in `data.py` that encapsulates all necessary score information
- `EXTERNAL_GRADER_SCORE_SUBMITTED` signal in `signals.py` to broadcast scoring events

This implementation provides a standardized way for the edx-submissions service to notify the LMS when an external grader has processed a submission. The event-driven approach offers several advantages over the current HTTP callback system:

- Decoupling of services for better reliability
- Improved scalability through asynchronous processing
- Enhanced monitoring and debugging capabilities
- Simplified system architecture

The `ExternalGraderScoreData` class contains all the necessary information for the LMS to properly render and display grading results to students, including:
- Points earned and points possible
- Course and module identifiers
- User identification for proper student attribution
- Original grader response message
- Queue information for traceability

## Supporting information

This PR is part of the broader FC-73 initiative to modernize the external grading architecture. While this PR only adds the event definition and data model, subsequent PRs will:
1. Implement the event emission in the XQueueViewSet
2. Add the event handling in the LMS to update XBlocks

## Testing instructions

1. Verify that the `ExternalGraderScoreData` class contains all necessary fields:
   - `points_possible`
   - `points_earned`
   - `course_id`
   - `score_msg`
   - `submission_id`
   - `user_id`
   - `module_id`
   - `queue_key`
   - `queue_name`

2. Confirm the `EXTERNAL_GRADER_SCORE_SUBMITTED` signal is properly defined with appropriate documentation

3. Run unit tests to ensure data models and signals function as expected

## Deadline

None

## Other information

This PR lays the groundwork for an event-driven grading architecture, enabling a gradual migration away from the HTTP-based XQueue callback system. Future PRs will build on this foundation to complete the transition to an event-based approach.

### Integration Notes

- The event defined here will be emitted by the edx-submissions service when an external grader submits a score
- Consumers in edx-platform will need to listen for this event to render responses to students
- This implementation maintains backward compatibility while enabling the new event-driven approach