### PR TITLE
chore: fix python ci status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,8 +105,8 @@ Please do not report security issues in public. Please email security@openedx.or
     :target: https://pypi.python.org/pypi/openedx-events/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/openedx/openedx-events/workflows/Python%20CI/badge.svg?branch=main
-    :target: https://github.com/openedx/openedx-events/actions
+.. |ci-badge| image:: https://github.com/openedx/openedx-events/actions/workflows/ci.yml/badge.svg?branch=main
+    :target: https://github.com/openedx/openedx-events/actions/workflows/ci.yml
     :alt: CI
 
 .. |codecov-badge| image:: https://codecov.io/github/openedx/openedx-events/coverage.svg?branch=main


### PR DESCRIPTION
## Description

This PR fixes the Python CI status badge in the README. The badge was generated in **Actions > Python CI > [•••] > Create status badge**

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/bf515e63-e08f-4fad-94bb-407da00f20a4)

### After
![image](https://github.com/user-attachments/assets/0f6fa2bc-ee41-473e-9923-7761aeed75c0)

## Deadline

None

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
