### PR TITLE
refactor!: use LibraryCollectionLocator and LibraryContainerLocator in event data structures [FC-0083]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Change Log
 Unreleased
 __________
 
+[10.0.0] - 2024-04-04
+---------------------
+Changed
+~~~~~~~
+* **Breaking change**: LibraryCollectionData now takes only a LibraryCollectionLocator.
+* **Breaking change**: LibraryContainerData now takes only a LibraryContainerLocator.
+
 [9.20.0] - 2025-03-15
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "9.20.0"
+__version__ = "10.0.0"

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -12,7 +12,7 @@ from typing import BinaryIO, List
 
 import attr
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryLocatorV2, LibraryUsageLocatorV2
 
 
 @attr.s(frozen=True)
@@ -218,14 +218,12 @@ class LibraryCollectionData:
     Data related to a library collection that has changed.
 
     Attributes:
-        library_key (LibraryLocatorV2): a key that represents a content library.
-        collection_key (str): identifies the collection within the library's learning package
+        collection_key (LibraryCollectionLocator): identifies the collection within the library's learning package
         background (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
            i.e., the handler can run the task in background. By default it is False.
     """
 
-    library_key = attr.ib(type=LibraryLocatorV2)
-    collection_key = attr.ib(type=str)
+    collection_key = attr.ib(type=LibraryCollectionLocator)
     background = attr.ib(type=bool, default=False)
 
 

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -12,7 +12,12 @@ from typing import BinaryIO, List
 
 import attr
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryLocatorV2, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import (
+    LibraryCollectionLocator,
+    LibraryContainerLocator,
+    LibraryLocatorV2,
+    LibraryUsageLocatorV2,
+)
 
 
 @attr.s(frozen=True)
@@ -233,12 +238,10 @@ class LibraryContainerData:
     Data related to a library container that has changed.
 
     Attributes:
-        library_key (LibraryLocatorV2): a key that represents a content library.
-        container_key (str): identifies the container within the library's learning package (e.g.  unit, section)
+        container_key (LibraryContainerLocator): identifies the container (e.g.  unit, section)
         background (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
            i.e., the handler can run the task in background. By default it is False.
     """
 
-    library_key = attr.ib(type=LibraryLocatorV2)
-    container_key = attr.ib(type=str)
+    container_key = attr.ib(type=LibraryContainerLocator)
     background = attr.ib(type=bool, default=False)

--- a/openedx_events/event_bus/avro/custom_serializers.py
+++ b/openedx_events/event_bus/avro/custom_serializers.py
@@ -8,7 +8,12 @@ from uuid import UUID
 
 from ccx_keys.locator import CCXLocator
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryLocatorV2, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import (
+    LibraryCollectionLocator,
+    LibraryContainerLocator,
+    LibraryLocatorV2,
+    LibraryUsageLocatorV2,
+)
 
 from openedx_events.event_bus.avro.types import PYTHON_TYPE_TO_AVRO_MAPPING
 
@@ -131,6 +136,25 @@ class LibraryCollectionLocatorAvroSerializer(BaseCustomTypeAvroSerializer):
         return LibraryCollectionLocator.from_string(data)
 
 
+class LibraryContainerLocatorAvroSerializer(BaseCustomTypeAvroSerializer):
+    """
+    CustomTypeAvroSerializer for LibraryContainerLocator class.
+    """
+
+    cls = LibraryContainerLocator
+    field_type = PYTHON_TYPE_TO_AVRO_MAPPING[str]
+
+    @staticmethod
+    def serialize(obj) -> str:
+        """Serialize obj into string."""
+        return str(obj)
+
+    @staticmethod
+    def deserialize(data: str):
+        """Deserialize string into obj."""
+        return LibraryContainerLocator.from_string(data)
+
+
 class LibraryLocatorV2AvroSerializer(BaseCustomTypeAvroSerializer):
     """
     CustomTypeAvroSerializer for LibraryLocatorV2 class.
@@ -195,6 +219,7 @@ DEFAULT_CUSTOM_SERIALIZERS = [
     CcxCourseLocatorAvroSerializer,
     DatetimeAvroSerializer,
     LibraryCollectionLocatorAvroSerializer,
+    LibraryContainerLocatorAvroSerializer,
     LibraryLocatorV2AvroSerializer,
     LibraryUsageLocatorV2AvroSerializer,
     UsageKeyAvroSerializer,

--- a/openedx_events/event_bus/avro/custom_serializers.py
+++ b/openedx_events/event_bus/avro/custom_serializers.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from ccx_keys.locator import CCXLocator
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryLocatorV2, LibraryUsageLocatorV2
 
 from openedx_events.event_bus.avro.types import PYTHON_TYPE_TO_AVRO_MAPPING
 
@@ -112,6 +112,25 @@ class UsageKeyAvroSerializer(BaseCustomTypeAvroSerializer):
         return UsageKey.from_string(data)
 
 
+class LibraryCollectionLocatorAvroSerializer(BaseCustomTypeAvroSerializer):
+    """
+    CustomTypeAvroSerializer for LibraryCollectionLocator class.
+    """
+
+    cls = LibraryCollectionLocator
+    field_type = PYTHON_TYPE_TO_AVRO_MAPPING[str]
+
+    @staticmethod
+    def serialize(obj) -> str:
+        """Serialize obj into string."""
+        return str(obj)
+
+    @staticmethod
+    def deserialize(data: str):
+        """Deserialize string into obj."""
+        return LibraryCollectionLocator.from_string(data)
+
+
 class LibraryLocatorV2AvroSerializer(BaseCustomTypeAvroSerializer):
     """
     CustomTypeAvroSerializer for LibraryLocatorV2 class.
@@ -175,6 +194,7 @@ DEFAULT_CUSTOM_SERIALIZERS = [
     CourseKeyAvroSerializer,
     CcxCourseLocatorAvroSerializer,
     DatetimeAvroSerializer,
+    LibraryCollectionLocatorAvroSerializer,
     LibraryLocatorV2AvroSerializer,
     LibraryUsageLocatorV2AvroSerializer,
     UsageKeyAvroSerializer,

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+created+v1_schema.avsc
@@ -10,10 +10,6 @@
         "type": "record",
         "fields": [
           {
-            "name": "library_key",
-            "type": "string"
-          },
-          {
             "name": "collection_key",
             "type": "string"
           },

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+deleted+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+deleted+v1_schema.avsc
@@ -10,10 +10,6 @@
         "type": "record",
         "fields": [
           {
-            "name": "library_key",
-            "type": "string"
-          },
-          {
             "name": "collection_key",
             "type": "string"
           },

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+updated+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+collection+updated+v1_schema.avsc
@@ -10,10 +10,6 @@
         "type": "record",
         "fields": [
           {
-            "name": "library_key",
-            "type": "string"
-          },
-          {
             "name": "collection_key",
             "type": "string"
           },

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+created+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+created+v1_schema.avsc
@@ -10,10 +10,6 @@
         "type": "record",
         "fields": [
           {
-            "name": "library_key",
-            "type": "string"
-          },
-          {
             "name": "container_key",
             "type": "string"
           },

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+deleted+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+deleted+v1_schema.avsc
@@ -10,10 +10,6 @@
         "type": "record",
         "fields": [
           {
-            "name": "library_key",
-            "type": "string"
-          },
-          {
             "name": "container_key",
             "type": "string"
           },

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+updated+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+updated+v1_schema.avsc
@@ -10,10 +10,6 @@
         "type": "record",
         "fields": [
           {
-            "name": "library_key",
-            "type": "string"
-          },
-          {
             "name": "container_key",
             "type": "string"
           },

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -11,7 +11,12 @@ from fastavro import schemaless_reader, schemaless_writer
 from fastavro.repository.base import SchemaRepositoryError
 from fastavro.schema import load_schema
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryLocatorV2, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import (
+    LibraryCollectionLocator,
+    LibraryContainerLocator,
+    LibraryLocatorV2,
+    LibraryUsageLocatorV2,
+)
 
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer, deserialize_bytes_to_event_data
 from openedx_events.event_bus.avro.serializer import AvroSignalSerializer, serialize_event_data_to_bytes
@@ -110,6 +115,9 @@ def generate_test_event_data_for_data_type(data_type):  # pragma: no cover
             "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
         ),
         LibraryCollectionLocator: LibraryCollectionLocator.from_string('lib-collection:MITx:reallyhardproblems:col1'),
+        LibraryContainerLocator: LibraryContainerLocator.from_string(
+            'lct:MITx:reallyhardproblems:unit:test-container',
+        ),
         LibraryLocatorV2: LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems'),
         LibraryUsageLocatorV2: LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),
         List[int]: [1, 2, 3],
@@ -128,6 +136,9 @@ def generate_test_event_data_for_data_type(data_type):  # pragma: no cover
         dict[str, LibraryLocatorV2]: {'key': LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems')},
         dict[str, LibraryCollectionLocator]: {
             'key': LibraryCollectionLocator.from_string('lib-collection:MITx:reallyhardproblems:col1'),
+        },
+        dict[str, LibraryContainerLocator]: {
+            'key': LibraryContainerLocator.from_string('lct:MITx:reallyhardproblems:unit:test-container'),
         },
         dict[str, LibraryUsageLocatorV2]: {
             'key': LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -11,7 +11,7 @@ from fastavro import schemaless_reader, schemaless_writer
 from fastavro.repository.base import SchemaRepositoryError
 from fastavro.schema import load_schema
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
+from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryLocatorV2, LibraryUsageLocatorV2
 
 from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer, deserialize_bytes_to_event_data
 from openedx_events.event_bus.avro.serializer import AvroSignalSerializer, serialize_event_data_to_bytes
@@ -109,6 +109,7 @@ def generate_test_event_data_for_data_type(data_type):  # pragma: no cover
         UsageKey: UsageKey.from_string(
             "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
         ),
+        LibraryCollectionLocator: LibraryCollectionLocator.from_string('lib-collection:MITx:reallyhardproblems:col1'),
         LibraryLocatorV2: LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems'),
         LibraryUsageLocatorV2: LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),
         List[int]: [1, 2, 3],
@@ -125,6 +126,9 @@ def generate_test_event_data_for_data_type(data_type):  # pragma: no cover
             "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
         )},
         dict[str, LibraryLocatorV2]: {'key': LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems')},
+        dict[str, LibraryCollectionLocator]: {
+            'key': LibraryCollectionLocator.from_string('lib-collection:MITx:reallyhardproblems:col1'),
+        },
         dict[str, LibraryUsageLocatorV2]: {
             'key': LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),
         },


### PR DESCRIPTION
<!--

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

For more details on the Hooks Extension Framework contribution process, see:

https://docs.openedx.org/en/latest/developers/concepts/hooks_extension_framework.html

-->

## Description

Refactors the LibraryCollectionData and LibraryContainerData structures to use LibraryCollectionLocator and LibraryContainerLocator keys, respectively, instead of passing `library_key` + string key representation.

We also remove the `library_key` from these data structures -- the library_key can be inferred from the opaque key, so it is redundant to pass them separately.

This refactoring seems reasonable to do without going through deprecation, given the minimal use of these data structures.

## Supporting information

cf https://github.com/openedx/openedx-events/pull/479#discussion_r1998824771
Blocks: https://github.com/openedx/edx-platform/pull/36476
Private-ref: [FAL-4120](https://tasks.opencraft.com/browse/FAL-4120)

## Testing instructions

Code review + CI should be sufficient to verify this change.

## Deadline

ASAP -- would like to get this in before Teak

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added with short description of the change and current date
- [x] <strike>Documentation updated (not only docstrings)</strike> N/A
- [x] Integration with other services reviewed
- [x] <strike>Fixup commits are squashed away</strike> N/A
- [x] Unit tests added/updated
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)