### PR TITLE
feat: add LIBRARY_BLOCK_PUBLISHED, LIBRARY_CONTAINER_PUBLISHED events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,19 @@ Change Log
 Unreleased
 __________
 
+
+Added
+~~~~~
+
+* Added new ``LIBRARY_BLOCK_PUBLISHED`` event in authoring.
+* Added new ``LIBRARY_CONTAINER_PUBLISHED`` event in authoring.
+
+Changed
+~~~~~~~
+* Deprecated the ``update_blocks`` and ``background`` attributes of various
+  content library events in authoring.
+* Clarified the use case of various content library events in authoring.
+
 [10.1.0] - 2024-05-01
 ---------------------
 

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -165,8 +165,9 @@ class ContentLibraryData:
     Data related to a content library that has changed.
 
     Attributes:
-        library_key (LibraryLocatorV2): a key that represents a Blockstore-based content library.
-        update_blocks (bool): flag that indicates whether the content library blocks indexes should be updated.
+        library_key (LibraryLocatorV2): a key that represents a v2 content library.
+        update_blocks (bool): DEPRECATED flag to indicate whether the content library blocks indexes should be updated.
+            Now we send individual events for each updated item instead.
     """
 
     library_key = attr.ib(type=LibraryLocatorV2)
@@ -179,7 +180,7 @@ class LibraryBlockData:
     Data related to a library block that has changed.
 
     Attributes:
-        library_key (LibraryLocatorV2): a key that represents a Blockstore-based content library.
+        library_key (LibraryLocatorV2): a key that represents a v2 content library.
         usage_key (LibraryUsageLocatorV2): a key that represents a XBlock in a Blockstore-based content library.
     """
 
@@ -224,8 +225,9 @@ class LibraryCollectionData:
 
     Attributes:
         collection_key (LibraryCollectionLocator): identifies the collection within the library's learning package
-        background (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
-           i.e., the handler can run the task in background. By default it is False.
+        background (bool): **DEPRECATED** field. Indicated the sender doesn't want to wait for handler to finish
+           execution. Now instead we recommend that simple handlers are synchronous and the _sender_ of the event should
+           send the event(s) from an async celery task if it is expected to result in a lot of handlers being called.
     """
 
     collection_key = attr.ib(type=LibraryCollectionLocator)
@@ -239,8 +241,9 @@ class LibraryContainerData:
 
     Attributes:
         container_key (LibraryContainerLocator): identifies the container (e.g.  unit, section)
-        background (bool): indicate whether the sender doesn't want to wait for handler to finish execution,
-           i.e., the handler can run the task in background. By default it is False.
+        background (bool): **DEPRECATED** field. Indicated the sender doesn't want to wait for handler to finish
+           execution. Now instead we recommend that simple handlers are synchronous and the _sender_ of the event should
+           send the event(s) from an async celery task if it is expected to result in a lot of handlers being called.
     """
 
     container_key = attr.ib(type=LibraryContainerLocator)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -160,7 +160,12 @@ CONTENT_LIBRARY_CREATED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.content_library.updated.v1
 # .. event_name: CONTENT_LIBRARY_UPDATED
-# .. event_description: Emitted when a content library is updated.
+# .. event_description: Emitted when a content library is updated, such as its
+#       name is changed. This is NOT sent when the only changes are to items
+#       within the library, even though that affects the "last updated" and
+#       potentially "last published" or "has unpublished changes" aspects of the
+#       library overall. To detect those, subscribe to the detailed LIBRARY_*
+#       events.
 # .. event_data: ContentLibraryData
 # .. event_trigger_repository: openedx/edx-platform
 CONTENT_LIBRARY_UPDATED = OpenEdxPublicSignal(
@@ -184,7 +189,7 @@ CONTENT_LIBRARY_DELETED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.library_block.created.v1
 # .. event_name: LIBRARY_BLOCK_CREATED
-# .. event_description: Emitted when a library block is created.
+# .. event_description: Emitted when a library XBlock is created.
 # .. event_data: LibraryBlockData
 # .. event_trigger_repository: openedx/edx-platform
 LIBRARY_BLOCK_CREATED = OpenEdxPublicSignal(
@@ -196,7 +201,7 @@ LIBRARY_BLOCK_CREATED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.library_block.updated.v1
 # .. event_name: LIBRARY_BLOCK_UPDATED
-# .. event_description: Emitted when a library block is updated.
+# .. event_description: Emitted when a library XBlock (draft) is updated.
 # .. event_data: LibraryBlockData
 # .. event_trigger_repository: openedx/edx-platform
 LIBRARY_BLOCK_UPDATED = OpenEdxPublicSignal(
@@ -208,11 +213,24 @@ LIBRARY_BLOCK_UPDATED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.content_authoring.library_block.deleted.v1
 # .. event_name: LIBRARY_BLOCK_DELETED
-# .. event_description: Emitted when a library block is deleted.
+# .. event_description: Emitted when a library XBlock (draft) is deleted.
 # .. event_data: LibraryBlockData
 # .. event_trigger_repository: openedx/edx-platform
 LIBRARY_BLOCK_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.library_block.deleted.v1",
+    data={
+        "library_block": LibraryBlockData,
+    }
+)
+
+# .. event_type: org.openedx.content_authoring.library_block.published.v1
+# .. event_name: LIBRARY_BLOCK_PUBLISHED
+# .. event_description: Emitted when a library XBlock is published. Also when a
+#       library block draft is deleted and then the deletion is published.
+# .. event_data: LibraryBlockData
+# .. event_trigger_repository: openedx/edx-platform
+LIBRARY_BLOCK_PUBLISHED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.library_block.published.v1",
     data={
         "library_block": LibraryBlockData,
     }
@@ -226,7 +244,7 @@ LIBRARY_BLOCK_DELETED = OpenEdxPublicSignal(
 CONTENT_OBJECT_ASSOCIATIONS_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content.object.associations.changed.v1",
     data={
-        "content_object": ContentObjectChangedData
+        "content_object": ContentObjectChangedData,
     }
 )
 
@@ -238,7 +256,7 @@ CONTENT_OBJECT_ASSOCIATIONS_CHANGED = OpenEdxPublicSignal(
 CONTENT_OBJECT_TAGS_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content.object.tags.changed.v1",
     data={
-        "content_object": ContentObjectData
+        "content_object": ContentObjectData,
     }
 )
 
@@ -250,7 +268,7 @@ CONTENT_OBJECT_TAGS_CHANGED = OpenEdxPublicSignal(
 LIBRARY_COLLECTION_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content_library.collection.created.v1",
     data={
-        "library_collection": LibraryCollectionData
+        "library_collection": LibraryCollectionData,
     }
 )
 
@@ -262,7 +280,7 @@ LIBRARY_COLLECTION_CREATED = OpenEdxPublicSignal(
 LIBRARY_COLLECTION_UPDATED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content_library.collection.updated.v1",
     data={
-        "library_collection": LibraryCollectionData
+        "library_collection": LibraryCollectionData,
     }
 )
 
@@ -274,7 +292,7 @@ LIBRARY_COLLECTION_UPDATED = OpenEdxPublicSignal(
 LIBRARY_COLLECTION_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content_library.collection.deleted.v1",
     data={
-        "library_collection": LibraryCollectionData
+        "library_collection": LibraryCollectionData,
     }
 )
 
@@ -286,7 +304,7 @@ LIBRARY_COLLECTION_DELETED = OpenEdxPublicSignal(
 LIBRARY_CONTAINER_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content_library.container.created.v1",
     data={
-        "library_container": LibraryContainerData
+        "library_container": LibraryContainerData,
     }
 )
 
@@ -298,7 +316,7 @@ LIBRARY_CONTAINER_CREATED = OpenEdxPublicSignal(
 LIBRARY_CONTAINER_UPDATED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content_library.container.updated.v1",
     data={
-        "library_container": LibraryContainerData
+        "library_container": LibraryContainerData,
     }
 )
 
@@ -310,7 +328,20 @@ LIBRARY_CONTAINER_UPDATED = OpenEdxPublicSignal(
 LIBRARY_CONTAINER_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.content_authoring.content_library.container.deleted.v1",
     data={
-        "library_container": LibraryContainerData
+        "library_container": LibraryContainerData,
+    }
+)
+
+# .. event_type: org.openedx.content_authoring.content_library.container.published.v1
+# .. event_name: LIBRARY_CONTAINER_PUBLISHED
+# .. event_description: Emitted when a library container is published. Also when
+#       a library container draft is deleted and then the deletion is published.
+# .. event_data: LibraryContainerData
+# .. event_trigger_repository: openedx/edx-platform
+LIBRARY_CONTAINER_PUBLISHED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.content_library.container.published.v1",
+    data={
+        "library_container": LibraryContainerData,
     }
 )
 

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+published+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+content_library+container+published+v1_schema.avsc
@@ -1,0 +1,25 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "library_container",
+      "type": {
+        "name": "LibraryContainerData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "container_key",
+            "type": "string"
+          },
+          {
+            "name": "background",
+            "type": "boolean"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.content_library.container.published.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+library_block+published+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+library_block+published+v1_schema.avsc
@@ -1,0 +1,25 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "library_block",
+      "type": {
+        "name": "LibraryBlockData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "library_key",
+            "type": "string"
+          },
+          {
+            "name": "usage_key",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.library_block.published.v1"
+}


### PR DESCRIPTION
## Description

In order to solve [some bugs with our "publish all" functionality](https://github.com/openedx/frontend-app-authoring/issues/1871), I found it would be extremely helpful to differentiate `PUBLISHED` events from other library authoring events like `CREATED`, `UPDATED`, and `DELETED` which all refer to changes to draft blocks/containers, not published.

This PR does several things:
* Creates new `LIBRARY_BLOCK_PUBLISHED` and `LIBRARY_CONTAINER_PUBLISHED` events which indicate any time that the _published_ version of a library item has been modified, including if it is deleted. The existing events like `LIBRARY_BLOCK_UPDATED` are clarified to refer strictly to changes in the draft version, which is normal for the authoring environment.
* Clarifies the docstring on several events
* Deprecates `background=True` on any library events that had it. Instead, we'll emit the events from an async task so that handlers can be implemented simply and synchronously without ever causing performance problems.
* Deprecates the `update_blocks` of `CONTENT_LIBRARY_UPDATED` - before this meant to "update all blocks in the library" but now individual events will be sent out for each block that was actually changed. This allows much more efficient and fine-grained synchronization.

## Supporting information

See this discussion thread on a related PR: https://github.com/openedx/edx-platform/pull/36640#discussion_r2069555024

## Testing instructions

The revised/clarified/new events can be tested using https://github.com/openedx/edx-platform/pull/36640

## Deadline

ASAP - need this for the Teak release.

## Other information

This is not strictly a bugfix but it is an important clarification of the beta Content Libraries API that is required for [a critical bugfix](https://github.com/openedx/edx-platform/pull/36640), and it does not make any change to the event data format. If it is not appropriate for backporting to Teak, then I'll have to reconsider the approach entirely.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
