### PR TITLE
feat: add enterprise group deletion event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Change Log
 Unreleased
 __________
 
+[10.4.0] - 2025-07-21
+---------------------
+
+Added
+~~~~~
+
+* Added new ``ENTERPRISE_GROUP_DELETED`` event in enterprise.
+
+
 [10.3.0] - 2025-05-23
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "10.3.0"
+__version__ = "10.4.0"

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -234,7 +234,7 @@ class EnterpriseGroup:
     Django model definition:
     https://github.com/openedx/edx-enterprise/blob/4ae2831a02087747da7bee7ea5cdd1d22929a059/enterprise/models.py#L4701
 
-    Arguments:
+    Attributes:
         uuid (UUID): Primary identifier of the record.
     """
 

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -235,15 +235,7 @@ class EnterpriseGroup:
     https://github.com/openedx/edx-enterprise/blob/4ae2831a02087747da7bee7ea5cdd1d22929a059/enterprise/models.py#L4701
 
     Arguments:
-        id (int): Primary identifier of the record.
-        created (datetime): When the record was created.
-        modified (datetime): When the record was last modified.
-        enterprise_customer_user (EnterpriseCustomerUser): The enterprise learner to which this enrollment is attached.
-        course_id (CourseKey): The ID of the course in which the learner was enrolled.
-        saved_for_later (bool): Specifies whether a user marked this course as saved for later in the learner portal.
-        source_slug (str): DB slug for the source of the enrollment, e.g. "enrollment_task", "management_command", etc.
-        unenrolled (bool): Specifies whether the related LMS course enrollment object was unenrolled.
-        unenrolled_at (datetime): Specifies when the related LMS course enrollment object was unenrolled.
+        uuid (UUID): Primary identifier of the record.
     """
 
     uuid = attr.ib(type=UUID)

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -224,3 +224,25 @@ class LicensedEnterpriseCourseEnrollment(BaseEnterpriseFulfillment):
     """
 
     license_uuid = attr.ib(type=UUID, default=None)
+
+
+@attr.s(frozen=True)
+class EnterpriseGroup:
+    """
+    Attributes of an ``enterprise.EnterpriseGroup`` record.
+
+    Django model definition: https://github.com/openedx/edx-enterprise/blob/4ae2831a02087747da7bee7ea5cdd1d22929a059/enterprise/models.py#L4701
+
+    Arguments:
+        id (int): Primary identifier of the record.
+        created (datetime): When the record was created.
+        modified (datetime): When the record was last modified.
+        enterprise_customer_user (EnterpriseCustomerUser): The enterprise learner to which this enrollment is attached.
+        course_id (CourseKey): The ID of the course in which the learner was enrolled.
+        saved_for_later (bool): Specifies whether a user marked this course as saved for later in the learner portal.
+        source_slug (str): DB slug for the source of the enrollment, e.g. "enrollment_task", "management_command", etc.
+        unenrolled (bool): Specifies whether the related LMS course enrollment object was unenrolled.
+        unenrolled_at (datetime): Specifies when the related LMS course enrollment object was unenrolled.
+    """
+
+    uuid = attr.ib(type=UUID)

--- a/openedx_events/enterprise/data.py
+++ b/openedx_events/enterprise/data.py
@@ -231,7 +231,8 @@ class EnterpriseGroup:
     """
     Attributes of an ``enterprise.EnterpriseGroup`` record.
 
-    Django model definition: https://github.com/openedx/edx-enterprise/blob/4ae2831a02087747da7bee7ea5cdd1d22929a059/enterprise/models.py#L4701
+    Django model definition:
+    https://github.com/openedx/edx-enterprise/blob/4ae2831a02087747da7bee7ea5cdd1d22929a059/enterprise/models.py#L4701
 
     Arguments:
         id (int): Primary identifier of the record.

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -113,6 +113,12 @@ LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED = OpenEdxPublicSignal(
 )
 
 
+"""
+To test this event in LMS, you can use the following command:
+`python3 manage.py lms produce_event --signal openedx_events.enterprise.signals.ENTERPRISE_GROUP_DELETED \
+--topic enterprise-core --key-field enterprise_group.uuid \
+--data '{"enterprise_group": { "uuid": "d509a63b-eb11-4dc8-8b84-4688c7335110" }}'`
+"""
 # .. event_type: org.openedx.enterprise.enterprise_group.deleted.v1
 # .. event_name: ENTERPRISE_GROUP_DELETED
 # .. event_description: emitted when an EnterpriseGroup is deleted.
@@ -124,8 +130,3 @@ ENTERPRISE_GROUP_DELETED = OpenEdxPublicSignal(
         "enterprise_group": EnterpriseGroup,
     }
 )
-
-'''
-Test event:
-python3 manage.py lms produce_event --signal openedx_events.enterprise.signals.ENTERPRISE_GROUP_DELETED --topic enterprise-core --key-field enterprise_group.uuid --data '{"enterprise_group": { "uuid": "d509a63b-eb11-4dc8-8b84-4688c7335110" }}'
-'''

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -9,10 +9,10 @@ docs/decisions/0003-events-payload.rst
 """
 
 from openedx_events.enterprise.data import (
-  LearnerCreditEnterpriseCourseEnrollment,
-  LedgerTransaction,
-  SubsidyRedemption,
-  EnterpriseGroup
+    EnterpriseGroup,
+    LearnerCreditEnterpriseCourseEnrollment,
+    LedgerTransaction,
+    SubsidyRedemption,
 )
 from openedx_events.tooling import OpenEdxPublicSignal
 

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -112,9 +112,9 @@ LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED = OpenEdxPublicSignal(
 
 # .. event_type: org.openedx.enterprise.enterprise_group.deleted.v1
 # .. event_name: ENTERPRISE_GROUP_DELETED
-# .. event_description: emitted when a LearnerCreditEnterpriseCourseEnrollment is revoked. This most often happens when
-#      an enterprise learner unenrolls from a course which was LC-subsidized.
-# .. event_data: LearnerCreditEnterpriseCourseEnrollment
+# .. event_description: emitted when an EnterpriseGroup is deleted.
+# .. event_data: EnterpriseGroup
+# .. event_trigger_repository: openedx/edx-enterprise
 ENTERPRISE_GROUP_DELETED = OpenEdxPublicSignal(
     event_type="org.openedx.enterprise.enterprise_group.deleted.v1",
     data={

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -9,7 +9,10 @@ docs/decisions/0003-events-payload.rst
 """
 
 from openedx_events.enterprise.data import (
-  LearnerCreditEnterpriseCourseEnrollment, LedgerTransaction, SubsidyRedemption, EnterpriseGroup
+  LearnerCreditEnterpriseCourseEnrollment,
+  LedgerTransaction,
+  SubsidyRedemption,
+  EnterpriseGroup
 )
 from openedx_events.tooling import OpenEdxPublicSignal
 

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -8,7 +8,9 @@ They also must comply with the payload definition specified in
 docs/decisions/0003-events-payload.rst
 """
 
-from openedx_events.enterprise.data import LearnerCreditEnterpriseCourseEnrollment, LedgerTransaction, SubsidyRedemption
+from openedx_events.enterprise.data import (
+  LearnerCreditEnterpriseCourseEnrollment, LedgerTransaction, SubsidyRedemption, EnterpriseGroup
+)
 from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.enterprise.subsidy.redeemed.v1
@@ -104,5 +106,18 @@ LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED = OpenEdxPublicSignal(
     event_type="org.openedx.enterprise.learner_credit_course_enrollment.revoked.v1",
     data={
         "learner_credit_course_enrollment": LearnerCreditEnterpriseCourseEnrollment,
+    }
+)
+
+
+# .. event_type: org.openedx.enterprise.enterprise_group.deleted.v1
+# .. event_name: ENTERPRISE_GROUP_DELETED
+# .. event_description: emitted when a LearnerCreditEnterpriseCourseEnrollment is revoked. This most often happens when
+#      an enterprise learner unenrolls from a course which was LC-subsidized.
+# .. event_data: LearnerCreditEnterpriseCourseEnrollment
+ENTERPRISE_GROUP_DELETED = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.enterprise_group.deleted.v1",
+    data={
+        "enterprise_group": EnterpriseGroup,
     }
 )

--- a/openedx_events/enterprise/signals.py
+++ b/openedx_events/enterprise/signals.py
@@ -124,3 +124,8 @@ ENTERPRISE_GROUP_DELETED = OpenEdxPublicSignal(
         "enterprise_group": EnterpriseGroup,
     }
 )
+
+'''
+Test event:
+python3 manage.py lms produce_event --signal openedx_events.enterprise.signals.ENTERPRISE_GROUP_DELETED --topic enterprise-core --key-field enterprise_group.uuid --data '{"enterprise_group": { "uuid": "d509a63b-eb11-4dc8-8b84-4688c7335110" }}'
+'''

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+enterprise_group+deleted+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+enterprise+enterprise_group+deleted+v1_schema.avsc
@@ -1,0 +1,21 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "enterprise_group",
+      "type": {
+        "name": "EnterpriseGroup",
+        "type": "record",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.enterprise.enterprise_group.deleted.v1"
+}


### PR DESCRIPTION
## Testing Instructions

- Have event bus running locally. Not set up? Easiest to have me screen share.
- If you have the event bus up, `pip install -e` this into a repo where it can be used and where event bus is configured correctly, and then run this: (if the repo is lms, change command to run `python2 manage.py lms produce_event ...` instead)
- `python3 manage.py produce_event --signal openedx_events.enterprise.signals.ENTERPRISE_GROUP_DELETED \
--topic enterprise-core --key-field enterprise_group.uuid \
--data '{"enterprise_group": { "uuid": "d509a63b-eb11-4dc8-8b84-4688c7335110" }}'`
- Verify that message in event bus is created.

## Description

If a budget Group is manually deleted (e.g. through django admin), but the PolicyGroupAssociation is not, we end up in a weird state where the budget is looking for a group that doesn’t exist anymore. We should automatically trigger a delete of any PolicyGroupAssociations with the same group ID whenever a budget Group is deleted.

The plan is to

- Utilize openedx-events with kafka to send an async event from edx-enterprise to our event broker
- Create a consumer on enterprise-access consume this event and delete the corresponding PolicyGroupAssociation

Internal 2U ticket: https://2u-internal.atlassian.net/browse/ENT-10440
Edx-enterprise Producer PR: https://github.com/openedx/edx-enterprise/pull/2413

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
