### PR TITLE
feat: add signal that is triggered after a course is re-run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Change Log
 Unreleased
 __________
 
+[10.5.0] - 2025-08-19
+---------------------
+
+Added
+~~~~~
+
+* Added new ``COURSE_RERUN_COMPLETED`` event in authoring.
+
+
 [10.4.0] - 2025-07-21
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "10.4.0"
+__version__ = "10.5.0"

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -357,3 +357,16 @@ COURSE_IMPORT_COMPLETED = OpenEdxPublicSignal(
         "course": CourseData,
     }
 )
+
+# .. event_type: org.openedx.content_authoring.course.rerun.completed.v1
+# .. event_name: COURSE_RERUN_COMPLETED
+# .. event_key_field: catalog_info.course_key
+# .. event_description: Fired after a course is re-run
+# .. event_data: CourseData
+# .. event_trigger_repository: openedx/edx-platform
+COURSE_RERUN_COMPLETED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.course.rerun.completed.v1",
+    data={
+        "course": CourseData,
+    }
+)

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+course+rerun+completed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+course+rerun+completed+v1_schema.avsc
@@ -1,0 +1,21 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "course",
+      "type": {
+        "name": "CourseData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "course_key",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.course.rerun.completed.v1"
+}


### PR DESCRIPTION
## Description

Adds `COURSE_RERUN_COMPLETED` signal which is similar to `COURSE_IMPORT_COMPLETED` signal. It is triggered after a course is re-run, allowing us to run some post re-run processes.

The current use of this is to run indexing for search and creation of upstream links for components imported from libraries v2.

## Supporting information

* https://github.com/openedx/frontend-app-authoring/issues/2361
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-4245
* https://github.com/openedx/edx-platform/pull/37237

## Testing instructions

See https://github.com/openedx/edx-platform/pull/37124

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added with short description of the change and current date
- [x] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
