### PR TITLE
chore: update owner in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,6 +10,6 @@ metadata:
   annotations:
     openedx.org/arch-interest-groups: "mariajgrimaldi,felipemontoya"
 spec:
-  owner: group:hooks-extension-framework
+  owner: group:committers-openedx-events
   type: 'source-code'
   lifecycle: 'production'


### PR DESCRIPTION
<!--

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

For more details on the Hooks Extension Framework contribution process, see:

https://docs.openedx.org/en/latest/developers/concepts/hooks_extension_framework.html

-->

## Description

This PR updates the code owners in backstage from the old naming convention to the new one.

## Supporting information

This issue was raised by Sarina in: https://github.com/openedx/openedx-events/issues/523

I'll be requesting a review from the members of the new group which both members of the old are part of.

## Deadline

None, as this won't require a release. It is for backstage primarily.

## Other information

Same was done for the openedx-filters repo at: https://github.com/openedx/openedx-filters/pull/315

## Checklists

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [ ] Fixup commits are squashed away

**Post Merge:**
- [ ] Nothing
