### PR TITLE
feat: add PERSISTENT_SUBSECTION_GRADE_CHANGED

### DIFF
--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "10.5.0"
+__version__ = "10.6.0"

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_subsection_grade+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_subsection_grade+changed+v1_schema.avsc
@@ -1,0 +1,130 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "grade",
+      "type": {
+        "name": "PersistentSubsectionGradeData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user_id",
+            "type": "long"
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "subsection_edited_timestamp",
+            "type": "string"
+          },
+          {
+            "name": "grading_policy_hash",
+            "type": "string"
+          },
+          {
+            "name": "usage_key",
+            "type": "string"
+          },
+          {
+            "name": "weighted_graded_earned",
+            "type": "double"
+          },
+          {
+            "name": "weighted_graded_possible",
+            "type": "double"
+          },
+          {
+            "name": "weighted_total_earned",
+            "type": "double"
+          },
+          {
+            "name": "weighted_total_possible",
+            "type": "double"
+          },
+          {
+            "name": "first_attempted",
+            "type": "string"
+          },
+          {
+            "name": "visible_blocks",
+            "type": {
+              "type": "array",
+              "items": {
+                "name": "XBlockWithScoringData",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "usage_key",
+                    "type": "string"
+                  },
+                  {
+                    "name": "block_type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "version",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "graded",
+                    "type": "null"
+                  },
+                  {
+                    "name": "raw_possible",
+                    "type": "null"
+                  },
+                  {
+                    "name": "weight",
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "visible_blocks_hash",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.course.persistent_subsection_grade.changed.v1"
+}

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -266,10 +266,30 @@ class PersistentCourseGradeData:
 class XBlockWithScoringData(XBlockData):
     """
     A subclass of XBlockData that includes scoring related information.
+
+    Attributes:
+        usage_key (UsageKey): Identifier of the XBlock object.
+        block_type (str): type of block.
+        version (UsageKey): Identifier of the XBlock object with branch and
+            version data (optional). This could be used to get the exact version
+            of the XBlock object, but it is often not available and should not
+            be relied on.
+        graded (bool): does this block count towards the student's grade? This
+            will almost always be True, but can be False in special
+            circumstances. For more details, please see the documentation for
+            ``PersistentSubsectionGradeData``
+        raw_possible (float): Individual block types determine how many points
+            they are worth by default. The implementation of this varies between
+            XBlock classes. ProblemBlocks count the number of parts they have,
+            ORA uses points from an author-defined rubric, etc.
+        weight (float): How many points is the problem weighted to be. This is
+            what actually matters for the purposes of grade calculation.
+            Specifying weight allows authors to make certain problems worth more
+            than others.
     """
-    weight = attr.ib(float)
-    raw_possible = attr.ib(float)
     graded = attr.ib(bool)
+    raw_possible = attr.ib(float)
+    weight = attr.ib(float)
 
 
 @attr.s(frozen=True)
@@ -280,50 +300,103 @@ class PersistentSubsectionGradeData:
     This data is based on the fields available in the PersistentSubsectionGrade
     data model defined in the openedx-platform grades app.
 
+    In order to use this data, it's important to understand what it means for
+    something to be "graded" in our system, i.e. have the XBlock field
+    graded=True on a particular block. The ``graded`` attribute can be set at
+    any level of the hierarchy in OLX and it will inherit down. In practice, it
+    is applied to the subsection (``SequentialBlock``) by Studio as soon as you
+    mark it with an assignment type (e.g. Homework, Midterm, Final), and we rely
+    on this inheritance behavior to mark all the components inside the
+    Subsection as having ``graded=True``. This has a couple of unintuitive
+    consequences:
+
+    1. All descendant Components will have ``graded=True``, even if they are not
+       block types that can hold a score, e.g. Text Components (HTMLBlock).
+    2. It is possible to set any particular problem to ``graded=False``.
+
+    There is no actual UI to modify the ``graded`` attribute of a problem in
+    Studio, and even the advanced editor will not actually persist your changes
+    properly. In order to really change this, you need to export and manually
+    modify the OLX to add ``graded="false"`` to the problem you want to target,
+    and then re-import the course. One use case for doing this is to allow
+    students to try an example/practice problem at the start of an assignment,
+    without it counting towards their grade.
+
+    This usage is extremely rare, but it is supported by the grading system,
+    even if the presentation to the user on the Progress page is confusing (the
+    ungraded problem scores are displayed individually but don't count towards
+    the total).
+
+    In summary: Unless you really, really know what you're doing, use
+    ``weighted_graded_earned`` and ``weighted_graded_possible`` to get the
+    grades for graded content, rather than using the more general
+    ``weighted_total_earned`` and ``weighted_total_possible`` that represents
+    all scorable content in the subsection. The latter fields exist for
+    backwards compatibility with the equivalent SUBSECTION_GRADE_CALCULATED
+    openedx-platform event, and because we do have some instances of people
+    taking advantage of this obscure feature.
+
     Attributes:
-        user_id (int): identifier of the user to which the grade belongs.
-        course (CourseData): Identifier of the course to which the grade belongs.
-        subsection_edited_timestamp (datetime): date the subsection was edited.
-        grading_policy_hash (str): grading policy hash of the course.
+        user_id (int): ID of the user to which the grade belongs.
+        course (CourseData): The course to which the grade belongs.
+        subsection_edited_timestamp (datetime): Datetime the subsection was
+            last edited.
+        grading_policy_hash (str): Grading policy hash of the course. A change
+            in this value from one even to the next means that *something* in
+            the grading policy has changed, but does not necessarily mean that
+            it had any affect on this subsection. A change might be to change
+            the relative weight a midterm and final exam have on the overall
+            course grade.
         usage_key (UsageKey): UsageKey of the subsection being graded.
+        weighted_graded_earned: How many graded points did the student earn in
+            this subsection. Prefer this over ``weighted_total_earned`` for most
+            use cases.
+        weighted_graded_possible (float): How many graded points were possible
+            for this student in this subsection. Prefer this over
+            ``weighted_total_possible`` for most use cases.
+        weighted_total_earned (float): How many points did the student earn in
+            this subsection, regardless of whether of not those points count
+            towards their grade (i.e. including things like practice problems).
+            You usually want to use ``weighted_graded_earned`` instead of this
+            field.
+        weighted_total_possible (float): How many points were possible for this
+            student in this subsection, regardless of whether or not those
+            points count towards their grade (i.e. including things like
+            practice problems). You usually want to use
+            ``weighted_graded_possible`` instead of this field.
+        first_attempted (datetime): When did the user first submit a problem'
+            attempt in this subsection?
+        visible_blocks (List[XBlockWithScoringData]): A flat list of XBlock data
+            that represents every scorable component in the subsection for this
+            student at the time that they attempted a problem. Every user may
+            see a slightly different permutation of subsection content depending
+            on various dynamic block types like ``LibraryContentBlock``, as well
+            access rules like cohorts and enrollment tracks. A student can only
+            be graded on what they have access to, so the total possible points
+            for a subsection may vary from student to student. Furthermore, the
+            content can also be edited by the course author after the students
+            have completed the assignment (this is bad practice, but the system
+            allows it). Therefore, the ``visible_blocks`` attribute can give us
+            an audit log of what the content was like at the time that the
+            student was graded.
+        visible_blocks_hash (str): A hash digest for the state of the visible
+            blocks for that user. Changes if anything anything related to
+            the grading information changes, e.g. adding or removing a problem,
+            or changing problem weights.
     """
     user_id = attr.ib(type=int)
     course = attr.ib(type=CourseData)
     subsection_edited_timestamp = attr.ib(type=datetime)
     grading_policy_hash = attr.ib(type=str)
-
     usage_key = attr.ib(type=UsageKey)
 
-    # The "graded" attribute can be set on individual problems if desired, so
-    # this is what's supposed to count towards their progress page/grades. Other
-    # ungraded problems may exist (e.g. practice problems). In practice, this
-    # will almost never happen because marking individual problems as ungraded
-    # requires manually editing XML via import or the advanced editor.
-    # Regardless, if you want to answer the question of, "What did the user earn
-    # for this assignment?", use these fields.
     weighted_graded_earned = attr.ib(type=float)
     weighted_graded_possible = attr.ib(type=float)
-
-    # This represents the earned/possible for all XBlock types that are capable
-    # of holding scoring data in this subsection, regardless of whether they are
-    # marked as "graded" or not, i.e. regardless of whether these points count
-    # towards the student's progress page and final grade. This may have some
-    # obscure use cases, like if for some reason you want to judge mastery based
-    # on an assignment that does not actually count towards the grade of the
-    # course it's in. Overall, this is just here to ensure parity with the
-    # pre-existing event emitted by openedx-platform.
     weighted_total_earned = attr.ib(type=float)
     weighted_total_possible = attr.ib(type=float)
 
     first_attempted = attr.ib(type=datetime)
 
-    # Every user may see a slightly different permutation of subsection content
-    # depending on various dynamic block types like LibraryContentBlock, as well
-    # access rules like cohorts and enrollment tracks. A student can only be
-    # graded on what they have access to, so the total possible grade may vary
-    # from student to student. The visible_blocks attribute captures all the
-    # blocks that were available to this user at the time their subsection grade
-    # was updated.
     visible_blocks = attr.ib(type=List[XBlockWithScoringData])
     visible_blocks_hash = attr.ib(type=str)
 

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -24,6 +24,7 @@ from openedx_events.learning.data import (
     LtiProviderLaunchData,
     ORASubmissionData,
     PersistentCourseGradeData,
+    PersistentSubsectionGradeData,
     ProgramCertificateData,
     UserData,
     UserNotificationData,
@@ -203,6 +204,19 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.persistent_grade_summary.changed.v1",
     data={
         "grade": PersistentCourseGradeData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.course.persistent_subsection_grade.changed.v1
+# .. event_name: PERSISTENT_SUBSECTION_GRADE_CHANGED
+# .. event_description: Emitted when a course's persistent grade summary changes for a user.
+# .. event_data: PersistentSubsectionGradeData
+# .. event_trigger_repository: openedx/edx-platform
+PERSISTENT_SUBSECTION_GRADE_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.persistent_subsection_grade.changed.v1",
+    data={
+        "grade": PersistentSubsectionGradeData,
     }
 )
 


### PR DESCRIPTION
Implementation of https://github.com/openedx/openedx-events/issues/542

## Description

We already have a [PERSISTENT_GRADE_CHANGED](https://github.com/openedx/openedx-events/blob/fc73ec5dff824c87955fd384359bd01694eedc5f/openedx_events/learning/data.py#L235) event, but we do not have a corresponding event for the subsection.

This mostly borrows the field data already calculated for openedx-platform's [SUBSECTION_GRADE_CALCULATED tracking event](https://github.com/openedx/openedx-platform/blob/497ffae5a75af1344d8e4dfb96a57996a5018c23/lms/djangoapps/grades/events.py#L108-L134).

I don't love the fact that we are putting the model name in the event name (`PersistentSubsectionGrade`), but I think it's better to be consistent with the already existing convention for emitting the course grade change event.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
