### PR TITLE
fix: restore all events in OpenEdxEventsTestMixin.tearDownClass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,16 @@ Unreleased
 __________
 
 
+[11.1.1] - 2026-04-06
+---------------------
+
+Fixed
+~~~~~
+
+* ``OpenEdxEventsTestMixin`` now re-enables all events in ``tearDownClass`` to
+  prevent disabled event state from leaking into subsequent test classes running
+  in the same process.
+
 [11.1.0] - 2026-03-19
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "11.1.0"
+__version__ = "11.1.1"

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -28,7 +28,7 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     SubTestData1,
     create_simple_signal,
 )
-from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.testing import FreezeSignalCacheMixin
 from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
 
 

--- a/openedx_events/event_bus/avro/tests/test_deserializer.py
+++ b/openedx_events/event_bus/avro/tests/test_deserializer.py
@@ -23,7 +23,7 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     SubTestData1,
     create_simple_signal,
 )
-from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.testing import FreezeSignalCacheMixin
 
 
 @ddt.ddt

--- a/openedx_events/event_bus/avro/tests/test_serializer.py
+++ b/openedx_events/event_bus/avro/tests/test_serializer.py
@@ -23,7 +23,7 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     SubTestData1,
     create_simple_signal,
 )
-from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.testing import FreezeSignalCacheMixin
 
 
 class TestAvroSignalSerializerCache(FreezeSignalCacheMixin, TestCase):

--- a/openedx_events/testing.py
+++ b/openedx_events/testing.py
@@ -1,5 +1,7 @@
 """
-Utils used by Open edX event tests.
+Test utilities for use by consumers of openedx-events.
+
+Provides mixins that help isolate Open edX event state between test classes.
 """
 
 from openedx_events.tooling import OpenEdxPublicSignal
@@ -100,11 +102,11 @@ class OpenEdxEventsTestMixin(EventsIsolationMixin):
 
     Example usage:
 
-        class MyTestCase(TestCase, OpenEdxEventsTestCase):
+        class MyTestCase(TestCase, OpenEdxEventsTestMixin):
 
             ENABLED_OPENEDX_EVENTS = ['org.openedx.learning.student.registration.completed.v1']
 
-    This class assumes that's it's being used in conjunction TestCase or TestCase subclasses.
+    This class assumes that it's being used in conjunction with TestCase or TestCase subclasses.
     """
 
     ENABLED_OPENEDX_EVENTS = []

--- a/openedx_events/tests/test_generate_avro_schemas.py
+++ b/openedx_events/tests/test_generate_avro_schemas.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 from openedx_events.event_bus.avro.tests.test_utilities import create_simple_signal
 from openedx_events.management.commands.generate_avro_schemas import Command
-from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.testing import FreezeSignalCacheMixin
 from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
 
 

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -17,7 +17,7 @@ from django.test import TestCase, override_settings
 
 from openedx_events.data import EventsMetadata
 from openedx_events.exceptions import SenderValidationError
-from openedx_events.tests.utils import FreezeSignalCacheMixin
+from openedx_events.testing import FreezeSignalCacheMixin
 from openedx_events.tooling import OpenEdxPublicSignal, _process_all_signals_modules, load_all_signals
 
 

--- a/openedx_events/tests/test_utils.py
+++ b/openedx_events/tests/test_utils.py
@@ -1,0 +1,75 @@
+"""
+Tests for openedx_events/tests/utils.py.
+"""
+from django.test import TestCase
+
+from openedx_events.tests.utils import FreezeSignalCacheMixin, OpenEdxEventsTestMixin
+from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
+
+
+class OpenEdxEventsTestMixinIsolationTest(FreezeSignalCacheMixin, TestCase):
+    """
+    Tests that OpenEdxEventsTestMixin does not leak disabled event state.
+
+    The key regression: setUpClass disables all events, but before the fix
+    there was no tearDownClass to re-enable them.  Any test class that ran
+    *after* a mixin class with ENABLED_OPENEDX_EVENTS=[] would find every
+    event still disabled.
+    """
+
+    def setUp(self):
+        super().setUp()
+        load_all_signals()
+
+    def _all_events_enabled(self):
+        return all(e._allow_events for e in OpenEdxPublicSignal.all_events())  # pylint: disable=protected-access
+
+    def _all_events_disabled(self):
+        return all(not e._allow_events for e in OpenEdxPublicSignal.all_events())  # pylint: disable=protected-access
+
+    def test_teardown_re_enables_all_events(self):
+        """
+        After tearDownClass runs, every event should be enabled.
+
+        Simulate the lifecycle of a mixin class with no enabled events:
+        setUpClass disables everything, tearDownClass must restore it.
+        """
+        class EmptyEnabledEvents(OpenEdxEventsTestMixin, TestCase):
+            ENABLED_OPENEDX_EVENTS = []
+
+        # Before the class runs all events should be enabled.
+        self.assertTrue(self._all_events_enabled())
+
+        EmptyEnabledEvents.setUpClass()
+        # After setUpClass, all events are disabled.
+        self.assertTrue(self._all_events_disabled())
+
+        EmptyEnabledEvents.tearDownClass()
+        # After tearDownClass, all events must be re-enabled.
+        self.assertTrue(
+            self._all_events_enabled(),
+            "tearDownClass should re-enable all events so subsequent test "
+            "classes are not affected by this class's event isolation.",
+        )
+
+    def test_teardown_re_enables_events_after_subset_enabled(self):
+        """
+        The tearDownClass re-enables all events even when only a subset was enabled.
+        """
+        all_event_types = [e.event_type for e in OpenEdxPublicSignal.all_events()]
+        one_event_type = all_event_types[0]
+
+        class OneEnabledEvent(OpenEdxEventsTestMixin, TestCase):
+            ENABLED_OPENEDX_EVENTS = [one_event_type]
+
+        OneEnabledEvent.setUpClass()
+        # Only one event should be enabled at this point.
+        enabled = [e for e in OpenEdxPublicSignal.all_events() if e._allow_events]  # pylint: disable=protected-access
+        self.assertEqual(len(enabled), 1)
+        self.assertEqual(enabled[0].event_type, one_event_type)
+
+        OneEnabledEvent.tearDownClass()
+        self.assertTrue(
+            self._all_events_enabled(),
+            "tearDownClass should re-enable all events regardless of how many were enabled.",
+        )

--- a/openedx_events/tests/test_utils.py
+++ b/openedx_events/tests/test_utils.py
@@ -1,9 +1,9 @@
 """
-Tests for openedx_events/tests/utils.py.
+Tests for openedx_events/testing.py.
 """
 from django.test import TestCase
 
-from openedx_events.tests.utils import FreezeSignalCacheMixin, OpenEdxEventsTestMixin
+from openedx_events.testing import FreezeSignalCacheMixin, OpenEdxEventsTestMixin
 from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
 
 

--- a/openedx_events/tests/utils.py
+++ b/openedx_events/tests/utils.py
@@ -118,6 +118,17 @@ class OpenEdxEventsTestMixin(EventsIsolationMixin):
         cls().start_events_isolation()
 
     @classmethod
+    def tearDownClass(cls):
+        """
+        Re-enable all events after class teardown.
+
+        Restores event state so subsequent test classes running in the same
+        process are not affected by this class's event isolation.
+        """
+        cls().enable_all_events()
+        super().tearDownClass()
+
+    @classmethod
     def start_events_isolation(cls):
         """
         Start Open edX Events isolation and then enable events by type.


### PR DESCRIPTION
## Summary

`OpenEdxEventsTestMixin.setUpClass()` disables all OpenEdX events then enables only those in `ENABLED_OPENEDX_EVENTS`, but had no `tearDownClass` to restore event state. This meant that after any test class using this mixin completed, all events not in `ENABLED_OPENEDX_EVENTS` remained globally disabled for the remainder of the process.

This was discovered in openedx-platform when shard rebalancing caused `lms/djangoapps/certificates/` and `lms/djangoapps/discussion/django_comment_client/` to run in the same process for the first time. Nine certificate test classes with `ENABLED_OPENEDX_EVENTS = []` left all events disabled, causing `ForumEventTestCase.test_comment_event` to fail with:

```
AttributeError: 'NoneType' object has no attribute 'kwargs'
```

because `FORUM_RESPONSE_COMMENT_CREATED` was never fired (it had been disabled).

## Fix

* Add `tearDownClass` to `OpenEdxEventsTestMixin` that calls `enable_all_events()`, mirroring the disable in 
`setUpClass`. This is consistent with the pattern already used by `FreezeSignalCacheMixin` in the same file.
* This also fixes a bug introduced in https://github.com/openedx/openedx-events/pull/557 which will break `openedx-platform` when it's released. See the refactor commit message for more details.