### PR TITLE
feat: add authz supporting subdomain module and ADR-0018

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,18 @@ Change Log
 Unreleased
 __________
 
+[11.2.0] - 2026-04-20
+---------------------
+
+Added
+~~~~~
+
+* New module openedx_events/authz with ROLE_ASSIGNMENT_CREATED and
+  ROLE_ASSIGNMENT_DELETED events.
+* ADR-0018 documents the decision to use dedicated top-level modules for
+  supporting subdomains, with authz module recognized as a prior instance of the
+  same concept in https://github.com/openedx/openedx-events/pull/230
+
 
 [11.1.1] - 2026-04-06
 ---------------------

--- a/docs/decisions/0018-supporting-subdomain-modules.rst
+++ b/docs/decisions/0018-supporting-subdomain-modules.rst
@@ -1,0 +1,85 @@
+.. _ADR-18:
+
+0018: Supporting Subdomain Modules for Cross-Domain Events
+##########################################################
+
+Status
+******
+
+**Proposed**
+
+Context
+*******
+
+Events in ``openedx-events`` are organized into domain modules (e.g., ``learning``,
+``course_authoring``) following the Open edX architecture subdomains in
+:ref:`Architecture Subdomains Reference`. This works well when an event belongs
+to a single subdomain.
+
+The `edX DDD Bounded Contexts`_ documentation classifies subdomains as core,
+supporting, or generic. Supporting subdomains provide capabilities that multiple
+core subdomains depend on, without belonging to any of them. ``analytics`` is the
+existing example in ``openedx-events``.
+
+Authorization has the same character: role assignment events originate from
+``openedx-authz`` and are consumed across learning, content authoring, enterprise,
+and other areas. Its domain definition is independent of any single application,
+so the ``authz`` module introduced in this ADR is classified as supporting.
+
+Prior to this decision, there was no explicit guidance for supporting subdomain
+events, leaving contributors to make ad-hoc placement choices.
+
+Decision
+********
+
+We introduce dedicated top-level modules in ``openedx-events`` for supporting
+subdomains when their events cannot be meaningfully attributed to a single
+existing domain module.
+
+A supporting subdomain module is warranted when:
+
+* The subdomain provides a capability that multiple core subdomains depend on.
+* The events are meaningful to consumers across existing domain modules without
+  a clear primary owner among them.
+* Placing the events in any single existing domain module would reflect a
+  current implementation detail rather than a stable domain boundary.
+
+The ``authz`` module introduced in this branch applies this pattern to
+authorization events. The existing ``analytics`` module is recognized as a prior
+instance of the same concept.
+
+Consequences
+************
+
+1. Supporting subdomain events have a principled home grounded in the Open edX
+   DDD taxonomy, rather than an arbitrary placement.
+2. The pattern is consistent with how ``analytics`` is already organized, and
+   both are now explicitly grounded in the same classification.
+3. Supporting subdomain modules can evolve independently of any single
+   application's release cycle.
+4. Deciding whether a concern qualifies as a supporting subdomain requires
+   judgment. Without discipline, this can lead to module proliferation.
+
+Rejected Alternatives
+*********************
+
+* **Place authorization events under ``course_authoring``**: role assignment is
+  currently performed through an admin console accessed via Studio, but that is
+  a transitional implementation detail. The admin console is planned to evolve
+  into its own application, and role assignment is semantically an authorization
+  concern, not a content authoring one.
+* **Create a generic ``admin`` module**: authorization has a self-contained domain
+  definition that stands independently of any UI surface. "Admin" describes a user
+  role and an interface where tasks from multiple domains are aggregated - the
+  tasks themselves belong to their respective domains.
+* **Extend an existing module with a subdirectory**: this would misrepresent the
+  domain ownership of the events and contradict the existing top-level module
+  structure.
+
+References
+**********
+
+- `edX DDD Bounded Contexts`_
+- :ref:`Architecture Subdomains Reference`
+
+.. _edX DDD Bounded Contexts: https://openedx.atlassian.net/wiki/spaces/AC/pages/663224968/edX+DDD+Bounded+Contexts

--- a/docs/decisions/0018-supporting-subdomain-modules.rst
+++ b/docs/decisions/0018-supporting-subdomain-modules.rst
@@ -22,7 +22,7 @@ core subdomains depend on, without belonging to any of them. ``analytics`` is th
 existing example in ``openedx-events``.
 
 Authorization has the same character: role assignment events originate from
-``openedx-authz`` and are consumed across learning, content authoring, enterprise,
+``openedx-authz`` and could be consumed across learning, content authoring, enterprise,
 and other areas. Its domain definition is independent of any single application,
 so the ``authz`` module introduced in this ADR is classified as supporting.
 

--- a/docs/decisions/index.rst
+++ b/docs/decisions/index.rst
@@ -24,3 +24,4 @@ Architectural Decision Records (ADRs)
    0015-outbox-pattern-and-production-modes
    0016-event-design-practices
    0017-event-signal-for-external-grader-score-submission
+   0018-supporting-subdomain-modules

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "11.1.1"
+__version__ = "11.2.0"

--- a/openedx_events/authz/__init__.py
+++ b/openedx_events/authz/__init__.py
@@ -1,0 +1,6 @@
+"""
+Package for events related to the Open edX authorization framework.
+
+This package is not attached to a specific subdomain, as the events defined
+here are used across multiple subdomains.
+"""

--- a/openedx_events/authz/__init__.py
+++ b/openedx_events/authz/__init__.py
@@ -2,5 +2,5 @@
 Package for events related to the Open edX authorization framework.
 
 This package is not attached to a specific subdomain, as the events defined
-here are used across multiple subdomains.
+here are used across multiple subdomains (supporting).
 """

--- a/openedx_events/authz/data.py
+++ b/openedx_events/authz/data.py
@@ -1,0 +1,27 @@
+"""Data attributes for events related to the authorization framework."""
+
+from typing import Optional
+
+import attr
+
+
+@attr.s(frozen=True)
+class RoleAssignmentData:
+    """Data related to a specific role assignment.
+
+    A role assignment represents the assignment of a role to a subject (e.g., user)
+    within a specific scope (e.g., course, organization).
+
+    Attributes:
+        operation (str): The operation being performed (e.g., 'assign', 'revoke').
+        subject (str): The subject to which the role is assigned (e.g., 'user^john_doe').
+        role (str): The role that is assigned (e.g., 'course_admin').
+        scope (str): The scope in which the role is assigned (e.g., 'course-v1:edX+DemoX+Demo_Course').
+        actor (Optional[str]): The actor performing the operation (e.g., 'user^admin_user').
+            This is optional and may be None if the actor is not known or not applicable (system-initiated actions).
+    """
+    operation: str = attr.ib()
+    subject: str = attr.ib()
+    role: str = attr.ib()
+    scope: str = attr.ib()
+    actor: Optional[str] = attr.ib(default=None)

--- a/openedx_events/authz/data.py
+++ b/openedx_events/authz/data.py
@@ -1,7 +1,5 @@
 """Data attributes for events related to the authorization framework."""
 
-from typing import NamedTuple, Optional
-
 import attr
 
 
@@ -13,23 +11,16 @@ class RoleAssignmentData:
     within a specific scope (e.g., course, organization).
 
     Attributes:
-        operation (str): The operation being performed. Use ``OPERATIONS.created`` or
-            ``OPERATIONS.deleted``.
+        operation (str): The operation being performed (e.g., 'created', 'deleted').
         subject (str): The subject to which the role is assigned (e.g., 'user^john_doe').
         role (str): The role that is assigned (e.g., 'course_admin').
         scope (str): The scope in which the role is assigned (e.g., 'course-v1:edX+DemoX+Demo_Course').
-        actor (Optional[str]): Username of the user performing the operation.
+        actor (str): Username of the user performing the operation.
             None if not known or not applicable (system-initiated actions).
     """
 
-    class Operations(NamedTuple):
-        created: str = "created"
-        deleted: str = "deleted"
-
-    OPERATIONS = Operations()
-
-    operation: str = attr.ib(validator=attr.validators.in_(OPERATIONS))
-    subject: str = attr.ib()
-    role: str = attr.ib()
-    scope: str = attr.ib()
-    actor: Optional[str] = attr.ib(default=None)
+    operation = attr.ib(type=str)
+    subject = attr.ib(type=str)
+    role = attr.ib(type=str)
+    scope = attr.ib(type=str)
+    actor = attr.ib(type=str, default=None)

--- a/openedx_events/authz/data.py
+++ b/openedx_events/authz/data.py
@@ -1,6 +1,6 @@
 """Data attributes for events related to the authorization framework."""
 
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import attr
 
@@ -13,14 +13,22 @@ class RoleAssignmentData:
     within a specific scope (e.g., course, organization).
 
     Attributes:
-        operation (str): The operation being performed (e.g., 'assign', 'revoke').
+        operation (str): The operation being performed. Use ``OPERATIONS.created`` or
+            ``OPERATIONS.deleted``.
         subject (str): The subject to which the role is assigned (e.g., 'user^john_doe').
         role (str): The role that is assigned (e.g., 'course_admin').
         scope (str): The scope in which the role is assigned (e.g., 'course-v1:edX+DemoX+Demo_Course').
         actor (Optional[str]): The actor performing the operation (e.g., 'user^admin_user').
             This is optional and may be None if the actor is not known or not applicable (system-initiated actions).
     """
-    operation: str = attr.ib()
+
+    class Operations(NamedTuple):
+        created: str = "created"
+        deleted: str = "deleted"
+
+    OPERATIONS = Operations()
+
+    operation: str = attr.ib(validator=attr.validators.in_(OPERATIONS))
     subject: str = attr.ib()
     role: str = attr.ib()
     scope: str = attr.ib()

--- a/openedx_events/authz/data.py
+++ b/openedx_events/authz/data.py
@@ -18,8 +18,8 @@ class RoleAssignmentData:
         subject (str): The subject to which the role is assigned (e.g., 'user^john_doe').
         role (str): The role that is assigned (e.g., 'course_admin').
         scope (str): The scope in which the role is assigned (e.g., 'course-v1:edX+DemoX+Demo_Course').
-        actor (Optional[str]): The actor performing the operation (e.g., 'user^admin_user').
-            This is optional and may be None if the actor is not known or not applicable (system-initiated actions).
+        actor (Optional[str]): Username of the user performing the operation.
+            None if not known or not applicable (system-initiated actions).
     """
 
     class Operations(NamedTuple):

--- a/openedx_events/authz/data.py
+++ b/openedx_events/authz/data.py
@@ -5,7 +5,8 @@ import attr
 
 @attr.s(frozen=True)
 class RoleAssignmentData:
-    """Data related to a specific role assignment.
+    """
+    Data related to a specific role assignment.
 
     A role assignment represents the assignment of a role to a subject (e.g., user)
     within a specific scope (e.g., course, organization).

--- a/openedx_events/authz/data.py
+++ b/openedx_events/authz/data.py
@@ -16,12 +16,11 @@ class RoleAssignmentData:
         subject (str): The subject to which the role is assigned (e.g., 'user^john_doe').
         role (str): The role that is assigned (e.g., 'course_admin').
         scope (str): The scope in which the role is assigned (e.g., 'course-v1:edX+DemoX+Demo_Course').
-        actor (str): Username of the user performing the operation.
-            None if not known or not applicable (system-initiated actions).
+        actor_id (int): The database ID of the actor performing the operation, if available.
     """
 
     operation = attr.ib(type=str)
     subject = attr.ib(type=str)
     role = attr.ib(type=str)
     scope = attr.ib(type=str)
-    actor = attr.ib(type=str, default=None)
+    actor_id = attr.ib(type=int, default=None)

--- a/openedx_events/authz/signals.py
+++ b/openedx_events/authz/signals.py
@@ -1,4 +1,5 @@
-"""Standard Open edX events related to the Open edX authorization framework.
+"""
+Standard Open edX events related to the Open edX authorization framework.
 
 This module defines signals that are used to notify other parts of the system
 about changes or actions related to authorization.
@@ -6,7 +7,6 @@ about changes or actions related to authorization.
 
 from openedx_events.authz.data import RoleAssignmentData
 from openedx_events.tooling import OpenEdxPublicSignal
-
 
 # .. event_type: org.openedx.authz.role_assignment.created
 # .. event_name: ROLE_ASSIGNMENT_CREATED

--- a/openedx_events/authz/signals.py
+++ b/openedx_events/authz/signals.py
@@ -8,7 +8,6 @@ from openedx_events.authz.data import RoleAssignmentData
 from openedx_events.tooling import OpenEdxPublicSignal
 
 
-
 # .. event_type: org.openedx.authz.role_assignment.created
 # .. event_name: ROLE_ASSIGNMENT_CREATED
 # .. event_key_field: user.pii.username

--- a/openedx_events/authz/signals.py
+++ b/openedx_events/authz/signals.py
@@ -1,0 +1,37 @@
+"""Standard Open edX events related to the Open edX authorization framework.
+
+This module defines signals that are used to notify other parts of the system
+about changes or actions related to authorization.
+"""
+
+from openedx_events.authz.data import RoleAssignmentData
+from openedx_events.tooling import OpenEdxPublicSignal
+
+
+
+# .. event_type: org.openedx.authz.role_assignment.created
+# .. event_name: ROLE_ASSIGNMENT_CREATED
+# .. event_key_field: user.pii.username
+# .. event_description: Emitted when a role assignment is created in Open edX.
+# .. event_data: RoleAssignmentData
+# .. event_trigger_repository: openedx/openedx-authz
+ROLE_ASSIGNMENT_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.authz.role_assignment.created",
+    data={
+        "role_assignment": RoleAssignmentData,
+    }
+)
+
+
+# .. event_type: org.openedx.authz.role_assignment.deleted
+# .. event_name: ROLE_ASSIGNMENT_DELETED
+# .. event_key_field: user.pii.username
+# .. event_description: Emitted when a role assignment is deleted in Open edX.
+# .. event_data: RoleAssignmentData
+# .. event_trigger_repository: openedx/openedx-authz
+ROLE_ASSIGNMENT_DELETED = OpenEdxPublicSignal(
+    event_type="org.openedx.authz.role_assignment.deleted",
+    data={
+        "role_assignment": RoleAssignmentData,
+    }
+)

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+created_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+created_schema.avsc
@@ -26,10 +26,10 @@
             "type": "string"
           },
           {
-            "name": "actor",
+            "name": "actor_id",
             "type": [
               "null",
-              "string"
+              "long"
             ],
             "default": null
           }

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+created_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+created_schema.avsc
@@ -1,0 +1,41 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "role_assignment",
+      "type": {
+        "name": "RoleAssignmentData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "operation",
+            "type": "string"
+          },
+          {
+            "name": "subject",
+            "type": "string"
+          },
+          {
+            "name": "role",
+            "type": "string"
+          },
+          {
+            "name": "scope",
+            "type": "string"
+          },
+          {
+            "name": "actor",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.authz.role_assignment.created"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+deleted_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+deleted_schema.avsc
@@ -1,0 +1,41 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "role_assignment",
+      "type": {
+        "name": "RoleAssignmentData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "operation",
+            "type": "string"
+          },
+          {
+            "name": "subject",
+            "type": "string"
+          },
+          {
+            "name": "role",
+            "type": "string"
+          },
+          {
+            "name": "scope",
+            "type": "string"
+          },
+          {
+            "name": "actor",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.authz.role_assignment.deleted"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+deleted_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+authz+role_assignment+deleted_schema.avsc
@@ -26,10 +26,10 @@
             "type": "string"
           },
           {
-            "name": "actor",
+            "name": "actor_id",
             "type": [
               "null",
-              "string"
+              "long"
             ],
             "default": null
           }


### PR DESCRIPTION
## Description

This PR introduces the `authz` module as a supporting subdomain module in `openedx-events`, along with ADR-0018 to document the pattern.

Authorization events don't belong to any single existing domain module. Role assignments originate from `openedx-authz` and are consumed across learning, content authoring, enterprise, and other areas. Placing them under `course_authoring` (the current home of the admin console where role assignment happens today) would tie the module to a UI surface that is expected to move to its own application. ADR-0018 defines the criteria for supporting subdomain modules and establishes `analytics` as a prior instance of the same concept.

The module adds two public signals:

- `ROLE_ASSIGNMENT_CREATED`: emitted when a role is assigned to a subject
- `ROLE_ASSIGNMENT_DELETED`: emitted when a role assignment is removed

Both carry `RoleAssignmentData`, which holds the operation, subject, role, scope, and optional actor. Valid operation values are constrained via `RoleAssignmentData.OPERATIONS` (a `NamedTuple` with `created` and `deleted` fields), enforced at construction time with `attr.validators.in_`.

Design decisions are documented in [docs/decisions/0018-supporting-subdomain-modules.rst](https://github.com/openedx/openedx-events/pull/561/changes#diff-111db58dbbd3be42eafff8ff7162b10cd1dd96144eb75179e93f43c8e08cc766).

## Supporting information

- openedx/openedx-authz#261 (trigger repository, includes testing instructions)

## Testing instructions

See openedx/openedx-authz#261 for end-to-end testing instructions.

## Deadline

None.

## Other information

- The `analytics` module is the prior instance of the supporting subdomain pattern; this PR makes that classification explicit in ADR-0018.
- No existing signals or data classes are modified.

## Checklists

**Merge Checklist:**
- [x] All reviewers approved
- [x] Reviewer tested the code following the testing instructions
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added with short description of the change and current date
- [x] Documentation updated (not only docstrings)
- [x] Integration with other services reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
