### PR TITLE
DEMO: add RegistrationDemographicsCaptured public signal

### DIFF
--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+student+registration+demographics+captured+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+student+registration+demographics+captured+v1_schema.avsc
@@ -1,0 +1,63 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "demographics",
+      "type": {
+        "name": "RegistrationDemographicsData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user",
+            "type": {
+              "name": "UserData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "long"
+                },
+                {
+                  "name": "is_active",
+                  "type": "boolean"
+                },
+                {
+                  "name": "pii",
+                  "type": {
+                    "name": "UserPersonalData",
+                    "type": "record",
+                    "fields": [
+                      {
+                        "name": "username",
+                        "type": "string"
+                      },
+                      {
+                        "name": "email",
+                        "type": "string"
+                      },
+                      {
+                        "name": "name",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "pronouns",
+            "type": "string"
+          },
+          {
+            "name": "department",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.student.registration.demographics.captured.v1"
+}

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -693,3 +693,29 @@ class LtiProviderLaunchData:
     course_key = attr.ib(type=CourseKey)
     usage_key = attr.ib(type=UsageKey)
     launch_params = attr.ib(type=LtiProviderLaunchParamsData)
+
+
+@attr.s(frozen=True)
+class RegistrationDemographicsData:
+    """
+    Attributes defined for Open edX registration demographics object.
+
+    Fired alongside a successful registration when a deployment has
+    enabled an authn-form plugin slot that collects optional demographic
+    information about the learner.
+
+    Both ``pronouns`` and ``department`` default to the empty string so
+    receivers can be written without ``hasattr`` / ``None`` checks; a
+    deployment that has not enabled demographics collection simply never
+    fires the signal at all.
+
+    Arguments:
+        user (UserData): the just-registered user.
+        pronouns (str): free-text pronouns string. Empty if not provided.
+        department (str): department key from the operator-configured
+            allowlist. Empty if not provided.
+    """
+
+    user = attr.ib(type=UserData)
+    pronouns = attr.ib(type=str, default="")
+    department = attr.ib(type=str, default="")

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -25,6 +25,7 @@ from openedx_events.learning.data import (
     ORASubmissionData,
     PersistentCourseGradeData,
     ProgramCertificateData,
+    RegistrationDemographicsData,
     UserData,
     UserNotificationData,
     VerificationAttemptData,
@@ -515,5 +516,18 @@ LTI_PROVIDER_LAUNCH_SUCCESS = OpenEdxPublicSignal(
     event_type="org.openedx.learning.lti_provider.launch.success.v1",
     data={
         "launch_data": LtiProviderLaunchData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.student.registration.demographics.captured.v1
+# .. event_name: REGISTRATION_DEMOGRAPHICS_CAPTURED
+# .. event_description: emitted after STUDENT_REGISTRATION_COMPLETED when an
+#       authn-form plugin slot has collected optional demographic fields.
+# .. event_data: RegistrationDemographicsData
+REGISTRATION_DEMOGRAPHICS_CAPTURED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.student.registration.demographics.captured.v1",
+    data={
+        "demographics": RegistrationDemographicsData,
     }
 )


### PR DESCRIPTION
### For demonstration purposes only, do not merge.

Adds a new public signal, ``REGISTRATION_DEMOGRAPHICS_CAPTURED``, fired by LMS once a learner has successfully registered and any optional demographic fields collected by an authn-form plugin have been validated.

Why a new event rather than extending ``STUDENT_REGISTRATION_COMPLETED``?

* ``STUDENT_REGISTRATION_COMPLETED`` carries only ``UserData`` today. Adding optional demographic fields to it would force every existing receiver to deal with the new attrs, and would couple a generic registration event to one specific use case (demographics collection).
* A dedicated event lets deployments that don't collect demographics ignore it entirely, and lets deployments that do route it onto the event bus (Kafka/Redis) without touching the higher-volume registration-completed stream.
* Versioning the signal independently (``...captured.v1``) means future changes to demographic field shape don't require bumping ``STUDENT_REGISTRATION_COMPLETED``.

The payload is intentionally minimal: a ``UserData`` reference plus the two free-form string fields the plugin slot collects (``pronouns``, ``department``). Fields default to empty strings so receivers don't have to special-case "demographics not collected on this deployment". This is a known flawed design (hard coding those fields is an anti-pattern, we cover this in the workshop).

Reference: see the OEX 2026 Conference workshop "Make It Extensible: Adding Extension Points Where You Need Them". This event is the one its registration demographics plugin subscribes to.