### PR TITLE
feat: add PERSISTENT_SUBSECTION_GRADE_CHANGED

### DIFF
--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "11.2.0"
+__version__ = "11.3.0"

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_subsection_grade+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_subsection_grade+changed+v1_schema.avsc
@@ -1,0 +1,130 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "grade",
+      "type": {
+        "name": "PersistentSubsectionGradeData",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user_id",
+            "type": "long"
+          },
+          {
+            "name": "course",
+            "type": {
+              "name": "CourseData",
+              "type": "record",
+              "fields": [
+                {
+                  "name": "course_key",
+                  "type": "string"
+                },
+                {
+                  "name": "display_name",
+                  "type": "string"
+                },
+                {
+                  "name": "start",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                },
+                {
+                  "name": "end",
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "subsection_edited_timestamp",
+            "type": "string"
+          },
+          {
+            "name": "grading_policy_hash",
+            "type": "string"
+          },
+          {
+            "name": "usage_key",
+            "type": "string"
+          },
+          {
+            "name": "weighted_graded_earned",
+            "type": "double"
+          },
+          {
+            "name": "weighted_graded_possible",
+            "type": "double"
+          },
+          {
+            "name": "weighted_total_earned",
+            "type": "double"
+          },
+          {
+            "name": "weighted_total_possible",
+            "type": "double"
+          },
+          {
+            "name": "first_attempted",
+            "type": "string"
+          },
+          {
+            "name": "visible_blocks",
+            "type": {
+              "type": "array",
+              "items": {
+                "name": "XBlockWithScoringData",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "usage_key",
+                    "type": "string"
+                  },
+                  {
+                    "name": "block_type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "version",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "graded",
+                    "type": "null"
+                  },
+                  {
+                    "name": "raw_possible",
+                    "type": "null"
+                  },
+                  {
+                    "name": "weight",
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "visible_blocks_hash",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.learning.course.persistent_subsection_grade.changed.v1"
+}

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_subsection_grade+changed+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+learning+course+persistent_subsection_grade+changed+v1_schema.avsc
@@ -104,15 +104,15 @@
                   },
                   {
                     "name": "graded",
-                    "type": "null"
+                    "type": "boolean"
                   },
                   {
                     "name": "raw_possible",
-                    "type": "null"
+                    "type": "double"
                   },
                   {
                     "name": "weight",
-                    "type": "null"
+                    "type": "double"
                   }
                 ]
               }

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -1,4 +1,5 @@
 """Test interplay of the various Avro helper classes"""
+
 import io
 import os
 from datetime import datetime
@@ -18,8 +19,14 @@ from opaque_keys.edx.locator import (
     LibraryUsageLocatorV2,
 )
 
-from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer, deserialize_bytes_to_event_data
-from openedx_events.event_bus.avro.serializer import AvroSignalSerializer, serialize_event_data_to_bytes
+from openedx_events.event_bus.avro.deserializer import (
+    AvroSignalDeserializer,
+    deserialize_bytes_to_event_data,
+)
+from openedx_events.event_bus.avro.serializer import (
+    AvroSignalSerializer,
+    serialize_event_data_to_bytes,
+)
 from openedx_events.event_bus.avro.tests.test_utilities import (
     EventData,
     NestedAttrsWithDefaults,
@@ -29,7 +36,11 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     create_simple_signal,
 )
 from openedx_events.testing import FreezeSignalCacheMixin
-from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
+from openedx_events.tooling import (
+    KNOWN_UNSERIALIZABLE_SIGNALS,
+    OpenEdxPublicSignal,
+    load_all_signals,
+)
 
 
 def generate_test_data_for_schema(schema: dict[str, Any]) -> dict:  # pragma: no cover
@@ -217,53 +228,67 @@ def generate_test_event_data_for_data_type(data_type: Any) -> dict:  # pragma: n
         UsageKey: UsageKey.from_string(
             "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
         ),
-        LibraryCollectionLocator: LibraryCollectionLocator.from_string('lib-collection:MITx:reallyhardproblems:col1'),
-        LibraryContainerLocator: LibraryContainerLocator.from_string(
-            'lct:MITx:reallyhardproblems:unit:test-container',
+        LibraryCollectionLocator: LibraryCollectionLocator.from_string(
+            "lib-collection:MITx:reallyhardproblems:col1"
         ),
-        LibraryLocatorV2: LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems'),
-        LibraryUsageLocatorV2: LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),
+        LibraryContainerLocator: LibraryContainerLocator.from_string(
+            "lct:MITx:reallyhardproblems:unit:test-container",
+        ),
+        LibraryLocatorV2: LibraryLocatorV2.from_string("lib:MITx:reallyhardproblems"),
+        LibraryUsageLocatorV2: LibraryUsageLocatorV2.from_string(
+            "lb:MITx:reallyhardproblems:problem:problem1"
+        ),
         List[int]: [1, 2, 3],
         List[str]: ["hi", "there"],
         datetime: datetime.now(),
-        CCXLocator: CCXLocator(org='edx', course='DemoX', run='Demo_course', ccx='1'),
+        CCXLocator: CCXLocator(org="edx", course="DemoX", run="Demo_course", ccx="1"),
         UUID: uuid4(),
-        dict[str, str]: {'key': 'value'},
-        dict[str, int]: {'key': 1},
-        dict[str, float]: {'key': 1.0},
-        dict[str, bool]: {'key': True},
-        dict[str, CourseKey]: {'key': CourseKey.from_string("course-v1:edX+DemoX.1+2014")},
-        dict[str, UsageKey]: {'key': UsageKey.from_string(
-            "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
-        )},
-        dict[str, LibraryLocatorV2]: {'key': LibraryLocatorV2.from_string('lib:MITx:reallyhardproblems')},
+        dict[str, str]: {"key": "value"},
+        dict[str, int]: {"key": 1},
+        dict[str, float]: {"key": 1.0},
+        dict[str, bool]: {"key": True},
+        dict[str, CourseKey]: {
+            "key": CourseKey.from_string("course-v1:edX+DemoX.1+2014")
+        },
+        dict[str, UsageKey]: {
+            "key": UsageKey.from_string(
+                "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk",
+            )
+        },
+        dict[str, LibraryLocatorV2]: {
+            "key": LibraryLocatorV2.from_string("lib:MITx:reallyhardproblems")
+        },
         dict[str, LibraryCollectionLocator]: {
-            'key': LibraryCollectionLocator.from_string('lib-collection:MITx:reallyhardproblems:col1'),
+            "key": LibraryCollectionLocator.from_string(
+                "lib-collection:MITx:reallyhardproblems:col1"
+            ),
         },
         dict[str, LibraryContainerLocator]: {
-            'key': LibraryContainerLocator.from_string('lct:MITx:reallyhardproblems:unit:test-container'),
+            "key": LibraryContainerLocator.from_string(
+                "lct:MITx:reallyhardproblems:unit:test-container"
+            ),
         },
         dict[str, LibraryUsageLocatorV2]: {
-            'key': LibraryUsageLocatorV2.from_string('lb:MITx:reallyhardproblems:problem:problem1'),
+            "key": LibraryUsageLocatorV2.from_string(
+                "lb:MITx:reallyhardproblems:problem:problem1"
+            ),
         },
-        dict[str, List[int]]: {'key': [1, 2, 3]},
-        dict[str, List[str]]: {'key': ["hi", "there"]},
-        dict[str, dict[str, str]]: {'key': {'key': 'value'}},
-        dict[str, dict[str, int]]: {'key': {'key': 1}},
-        dict[str, Union[str, int]]: {'key': 'value'},
-        dict[str, Union[str, int, float]]: {'key': 1.0},
+        dict[str, List[int]]: {"key": [1, 2, 3]},
+        dict[str, List[str]]: {"key": ["hi", "there"]},
+        dict[str, dict[str, str]]: {"key": {"key": "value"}},
+        dict[str, dict[str, int]]: {"key": {"key": 1}},
+        dict[str, Union[str, int]]: {"key": "value"},
+        dict[str, Union[str, int, float]]: {"key": 1.0},
     }
 
     # Handle origin types
     origin_type = get_origin(data_type)
 
     if origin_type is not None:
-
         args = get_args(data_type)
 
         # Handle List types
         if origin_type is list:
-
             item_type = args[0]
 
             # Handle List of simple types, e.g. List[str]
@@ -275,15 +300,21 @@ def generate_test_event_data_for_data_type(data_type: Any) -> dict:  # pragma: n
                 dict_key_type, dict_value_type = get_args(item_type)
                 # Only support string keys for Avro compatibility
                 if dict_key_type is not str:
-                    raise TypeError("Avro maps only support string keys. The key type must be 'str'.")
+                    raise TypeError(
+                        "Avro maps only support string keys. The key type must be 'str'."
+                    )
 
                 sample_dict = {}
                 if get_origin(dict_value_type) is not None:
                     # Handle nested types in dictionary values, e.g. List[str]
-                    sample_dict = {"key": generate_test_event_data_for_data_type(dict_value_type)}
+                    sample_dict = {
+                        "key": generate_test_event_data_for_data_type(dict_value_type)
+                    }
                 else:
                     # Handle simple types in dictionary values, e.g. str
-                    default_value = defaults_per_type.get(dict_value_type, "default_value")
+                    default_value = defaults_per_type.get(
+                        dict_value_type, "default_value"
+                    )
                     sample_dict = {"key": default_value}
 
                 return [sample_dict]
@@ -294,12 +325,13 @@ def generate_test_event_data_for_data_type(data_type: Any) -> dict:  # pragma: n
 
         # Handle Dict types
         elif origin_type is dict:
-
             key_type, value_type = args[0], args[1]
 
             # Only support string keys for Avro compatibility
             if key_type is not str:
-                raise TypeError("Avro maps only support string keys. The key type must be 'str'.")
+                raise TypeError(
+                    "Avro maps only support string keys. The key type must be 'str'."
+                )
 
             # Handle Dict of simple types, e.g. Dict[str, str]
             if value_type in defaults_per_type:
@@ -316,11 +348,9 @@ def generate_test_event_data_for_data_type(data_type: Any) -> dict:  # pragma: n
 
     # Handle attrs classes
     if hasattr(data_type, "__attrs_attrs__"):
-
         data_dict = {}
 
         for attribute in data_type.__attrs_attrs__:
-
             result = defaults_per_type.get(attribute.type, None)
             # Handle simple types
             if result is not None:
@@ -329,7 +359,13 @@ def generate_test_event_data_for_data_type(data_type: Any) -> dict:  # pragma: n
                 # Handle origin types in attributes
                 origin = get_origin(attribute.type)
                 if origin is not None:
-                    data_dict.update({attribute.name: generate_test_event_data_for_data_type(attribute.type)})
+                    data_dict.update(
+                        {
+                            attribute.name: generate_test_event_data_for_data_type(
+                                attribute.type
+                            )
+                        }
+                    )
                 # Handle attrs classes
                 if hasattr(attribute.type, "__attrs_attrs__"):
                     attr_data = generate_test_event_data_for_data_type(attribute.type)
@@ -369,6 +405,7 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
 
     def test_all_events(self):
         for signal in OpenEdxPublicSignal.all_events():
+            print(signal)
             if signal.event_type in KNOWN_UNSERIALIZABLE_SIGNALS:
                 continue
             test_data = generate_test_data_for_signal(signal)
@@ -400,18 +437,26 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
             current_event_bytes = current_out.read()
 
             # get stored schema
-            schema_filename = f"{os.path.dirname(os.path.abspath(__file__))}/schemas/" \
-                              f"{signal.event_type.replace('.', '+')}_schema.avsc"
+            schema_filename = (
+                f"{os.path.dirname(os.path.abspath(__file__))}/schemas/"
+                f"{signal.event_type.replace('.', '+')}_schema.avsc"
+            )
             try:
                 stored_schema = load_schema(schema_filename)
             except SchemaRepositoryError:  # pragma: no cover
-                self.fail(f"Missing file {schema_filename}. If a new signal has been added, you may need to run the"
-                          f" generate_avro_schemas management command to save the signal schema.")
+                self.fail(
+                    f"Missing file {schema_filename}. If a new signal has been added, you may need to run the"
+                    f" generate_avro_schemas management command to save the signal schema."
+                )
 
             data_file_current = io.BytesIO(current_event_bytes)
 
             # read bytes using stored schema
-            schemaless_reader(data_file_current, reader_schema=stored_schema, writer_schema=schema_dict)
+            schemaless_reader(
+                data_file_current,
+                reader_schema=stored_schema,
+                writer_schema=schema_dict,
+            )
 
     def test_evolution_is_backward_compatible(self):
         """
@@ -431,13 +476,17 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
             schema_dict = serializer.schema
 
             # get stored schema
-            schema_filename = f"{os.path.dirname(os.path.abspath(__file__))}/schemas/" \
-                              f"{signal.event_type.replace('.', '+')}_schema.avsc"
+            schema_filename = (
+                f"{os.path.dirname(os.path.abspath(__file__))}/schemas/"
+                f"{signal.event_type.replace('.', '+')}_schema.avsc"
+            )
             try:
                 old_schema = load_schema(schema_filename)
             except SchemaRepositoryError:  # pragma: no cover
-                self.fail(f"Missing file {schema_filename}. If a new signal has been added, you may need to run the"
-                          f" generate_avro_schemas management command to save the signal schema.")
+                self.fail(
+                    f"Missing file {schema_filename}. If a new signal has been added, you may need to run the"
+                    f" generate_avro_schemas management command to save the signal schema."
+                )
             data_dict = generate_test_data_for_schema(old_schema)
 
             # write to bytes using stored schema
@@ -449,16 +498,20 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
             data_file_stored = io.BytesIO(stored_event_bytes)
 
             # read bytes using current schema
-            schemaless_reader(data_file_stored, reader_schema=schema_dict, writer_schema=old_schema)
+            schemaless_reader(
+                data_file_stored, reader_schema=schema_dict, writer_schema=old_schema
+            )
 
     def test_full_serialize_deserialize(self):
         SIGNAL = create_simple_signal({"test_data": EventData})
-        event_data = {"test_data": EventData(
-            "foo",
-            "bar.course",
-            SubTestData0("a.sub.name", "a.nother.course"),
-            SubTestData1("b.uber.sub.name", "b.uber.another.course"),
-        )}
+        event_data = {
+            "test_data": EventData(
+                "foo",
+                "bar.course",
+                SubTestData0("a.sub.name", "a.nother.course"),
+                SubTestData1("b.uber.sub.name", "b.uber.another.course"),
+            )
+        }
         serialized = serialize_event_data_to_bytes(event_data, SIGNAL)
         deserialized = deserialize_bytes_to_event_data(serialized, SIGNAL)
         self.assertIsInstance(deserialized["test_data"], EventData)
@@ -468,7 +521,9 @@ class TestAvro(FreezeSignalCacheMixin, TestCase):
 
     def test_full_serialize_deserialize_with_optional_fields(self):
         SIGNAL = create_simple_signal({"test_data": NestedAttrsWithDefaults})
-        event_data = {"test_data": NestedAttrsWithDefaults(field_0=SimpleAttrsWithDefaults())}
+        event_data = {
+            "test_data": NestedAttrsWithDefaults(field_0=SimpleAttrsWithDefaults())
+        }
         serialized = serialize_event_data_to_bytes(event_data, SIGNAL)
         deserialized = deserialize_bytes_to_event_data(serialized, SIGNAL)
         self.assertIsInstance(deserialized["test_data"], NestedAttrsWithDefaults)

--- a/openedx_events/event_bus/avro/tests/test_avro.py
+++ b/openedx_events/event_bus/avro/tests/test_avro.py
@@ -19,14 +19,8 @@ from opaque_keys.edx.locator import (
     LibraryUsageLocatorV2,
 )
 
-from openedx_events.event_bus.avro.deserializer import (
-    AvroSignalDeserializer,
-    deserialize_bytes_to_event_data,
-)
-from openedx_events.event_bus.avro.serializer import (
-    AvroSignalSerializer,
-    serialize_event_data_to_bytes,
-)
+from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer, deserialize_bytes_to_event_data
+from openedx_events.event_bus.avro.serializer import AvroSignalSerializer, serialize_event_data_to_bytes
 from openedx_events.event_bus.avro.tests.test_utilities import (
     EventData,
     NestedAttrsWithDefaults,
@@ -36,11 +30,7 @@ from openedx_events.event_bus.avro.tests.test_utilities import (
     create_simple_signal,
 )
 from openedx_events.testing import FreezeSignalCacheMixin
-from openedx_events.tooling import (
-    KNOWN_UNSERIALIZABLE_SIGNALS,
-    OpenEdxPublicSignal,
-    load_all_signals,
-)
+from openedx_events.tooling import KNOWN_UNSERIALIZABLE_SIGNALS, OpenEdxPublicSignal, load_all_signals
 
 
 def generate_test_data_for_schema(schema: dict[str, Any]) -> dict:  # pragma: no cover

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -294,7 +294,7 @@ class XBlockWithScoringData(XBlockData):
 
     graded = attr.ib(type=bool)
     raw_possible = attr.ib(type=float)
-    weight = attr.ib(type=float)
+    weight = attr.ib(type=float, default=None)
 
 
 @attr.s(frozen=True)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -11,6 +11,8 @@ import attr
 from ccx_keys.locator import CCXLocator
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
+from ..content_authoring.data import XBlockData
+
 
 @attr.s(frozen=True)
 class UserNonPersonalData:
@@ -243,7 +245,7 @@ class PersistentCourseGradeData:
     defined in the grades app.
 
     Attributes:
-        user_id (int): identifier of the grade to which the grade belongs.
+        user_id (int): identifier of the user to which the grade belongs.
         course (CourseData): Identifier of the course to which the grade belongs.
         course_edited_timestamp (datetime): date the course was edited.
         course_version (str): version of the course.
@@ -261,6 +263,72 @@ class PersistentCourseGradeData:
     percent_grade = attr.ib(type=float)
     letter_grade = attr.ib(type=str)
     passed_timestamp = attr.ib(type=datetime)
+
+
+@attr.s(frozen=True)
+class XBlockWithScoringData(XBlockData):
+    """
+    A subclass of XBlockData that includes scoring related information.
+    """
+    weight = attr.ib(float)
+    raw_possible = attr.ib(float)
+    graded = attr.ib(bool)
+
+
+@attr.s(frozen=True)
+class PersistentSubsectionGradeData:
+    """
+    Data related to a persistent subsection grade object.
+
+    This data is based on the fields available in the PersistentSubsectionGrade
+    data model defined in the openedx-platform grades app.
+
+    Attributes:
+        user_id (int): identifier of the user to which the grade belongs.
+        course (CourseData): Identifier of the course to which the grade belongs.
+        subsection_edited_timestamp (datetime): date the subsection was edited.
+        grading_policy_hash (str): grading policy hash of the course.
+        usage_key (UsageKey): UsageKey of the subsection being graded.
+    """
+    user_id = attr.ib(type=int)
+    course = attr.ib(type=CourseData)
+    subsection_edited_timestamp = attr.ib(type=datetime)
+    grading_policy_hash = attr.ib(type=str)
+
+    usage_key = attr.ib(type=UsageKey)
+
+    # The "graded" attribute can be set on individual problems if desired, so
+    # this is what's supposed to count towards their progress page/grades. Other
+    # ungraded problems may exist (e.g. practice problems). In practice, this
+    # will almost never happen because marking individual problems as ungraded
+    # requires manually editing XML via import or the advanced editor.
+    # Regardless, if you want to answer the question of, "What did the user earn
+    # for this assignment?", use these fields.
+    weighted_graded_earned = attr.ib(type=float)
+    weighted_graded_possible = attr.ib(type=float)
+
+    # This represents the earned/possible for all XBlock types that are capable
+    # of holding scoring data in this subsection, regardless of whether they are
+    # marked as "graded" or not, i.e. regardless of whether these points count
+    # towards the student's progress page and final grade. This may have some
+    # obscure use cases, like if for some reason you want to judge mastery based
+    # on an assignment that does not actually count towards the grade of the
+    # course it's in. Overall, this is just here to ensure parity with the
+    # pre-existing event emitted by openedx-platform.
+    weighted_total_earned = attr.ib(type=float)
+    weighted_total_possible = attr.ib(type=float)
+
+    first_attempted = attr.ib(type=datetime)
+
+    # Every user may see a slightly different permutation of subsection content
+    # depending on various dynamic block types like LibraryContentBlock, as well
+    # access rules like cohorts and enrollment tracks. A student can only be
+    # graded on what they have access to, so the total possible grade may vary
+    # from student to student. The visible_blocks attribute captures all the
+    # blocks that were available to this user at the time their subsection grade
+    # was updated.
+    visible_blocks = attr.ib(type=List[XBlockWithScoringData])
+    visible_blocks_hash = attr.ib(type=str)
 
 
 @attr.s(frozen=True)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -269,10 +269,30 @@ class PersistentCourseGradeData:
 class XBlockWithScoringData(XBlockData):
     """
     A subclass of XBlockData that includes scoring related information.
+
+    Attributes:
+        usage_key (UsageKey): Identifier of the XBlock object.
+        block_type (str): type of block.
+        version (UsageKey): Identifier of the XBlock object with branch and
+            version data (optional). This could be used to get the exact version
+            of the XBlock object, but it is often not available and should not
+            be relied on.
+        graded (bool): does this block count towards the student's grade? This
+            will almost always be True, but can be False in special
+            circumstances. For more details, please see the documentation for
+            ``PersistentSubsectionGradeData``
+        raw_possible (float): Individual block types determine how many points
+            they are worth by default. The implementation of this varies between
+            XBlock classes. ProblemBlocks count the number of parts they have,
+            ORA uses points from an author-defined rubric, etc.
+        weight (float): How many points is the problem weighted to be. This is
+            what actually matters for the purposes of grade calculation.
+            Specifying weight allows authors to make certain problems worth more
+            than others.
     """
-    weight = attr.ib(float)
-    raw_possible = attr.ib(float)
     graded = attr.ib(bool)
+    raw_possible = attr.ib(float)
+    weight = attr.ib(float)
 
 
 @attr.s(frozen=True)
@@ -283,50 +303,103 @@ class PersistentSubsectionGradeData:
     This data is based on the fields available in the PersistentSubsectionGrade
     data model defined in the openedx-platform grades app.
 
+    In order to use this data, it's important to understand what it means for
+    something to be "graded" in our system, i.e. have the XBlock field
+    graded=True on a particular block. The ``graded`` attribute can be set at
+    any level of the hierarchy in OLX and it will inherit down. In practice, it
+    is applied to the subsection (``SequentialBlock``) by Studio as soon as you
+    mark it with an assignment type (e.g. Homework, Midterm, Final), and we rely
+    on this inheritance behavior to mark all the components inside the
+    Subsection as having ``graded=True``. This has a couple of unintuitive
+    consequences:
+
+    1. All descendant Components will have ``graded=True``, even if they are not
+       block types that can hold a score, e.g. Text Components (HTMLBlock).
+    2. It is possible to set any particular problem to ``graded=False``.
+
+    There is no actual UI to modify the ``graded`` attribute of a problem in
+    Studio, and even the advanced editor will not actually persist your changes
+    properly. In order to really change this, you need to export and manually
+    modify the OLX to add ``graded="false"`` to the problem you want to target,
+    and then re-import the course. One use case for doing this is to allow
+    students to try an example/practice problem at the start of an assignment,
+    without it counting towards their grade.
+
+    This usage is extremely rare, but it is supported by the grading system,
+    even if the presentation to the user on the Progress page is confusing (the
+    ungraded problem scores are displayed individually but don't count towards
+    the total).
+
+    In summary: Unless you really, really know what you're doing, use
+    ``weighted_graded_earned`` and ``weighted_graded_possible`` to get the
+    grades for graded content, rather than using the more general
+    ``weighted_total_earned`` and ``weighted_total_possible`` that represents
+    all scorable content in the subsection. The latter fields exist for
+    backwards compatibility with the equivalent SUBSECTION_GRADE_CALCULATED
+    openedx-platform event, and because we do have some instances of people
+    taking advantage of this obscure feature.
+
     Attributes:
-        user_id (int): identifier of the user to which the grade belongs.
-        course (CourseData): Identifier of the course to which the grade belongs.
-        subsection_edited_timestamp (datetime): date the subsection was edited.
-        grading_policy_hash (str): grading policy hash of the course.
+        user_id (int): ID of the user to which the grade belongs.
+        course (CourseData): The course to which the grade belongs.
+        subsection_edited_timestamp (datetime): Datetime the subsection was
+            last edited.
+        grading_policy_hash (str): Grading policy hash of the course. A change
+            in this value from one even to the next means that *something* in
+            the grading policy has changed, but does not necessarily mean that
+            it had any affect on this subsection. A change might be to change
+            the relative weight a midterm and final exam have on the overall
+            course grade.
         usage_key (UsageKey): UsageKey of the subsection being graded.
+        weighted_graded_earned: How many graded points did the student earn in
+            this subsection. Prefer this over ``weighted_total_earned`` for most
+            use cases.
+        weighted_graded_possible (float): How many graded points were possible
+            for this student in this subsection. Prefer this over
+            ``weighted_total_possible`` for most use cases.
+        weighted_total_earned (float): How many points did the student earn in
+            this subsection, regardless of whether of not those points count
+            towards their grade (i.e. including things like practice problems).
+            You usually want to use ``weighted_graded_earned`` instead of this
+            field.
+        weighted_total_possible (float): How many points were possible for this
+            student in this subsection, regardless of whether or not those
+            points count towards their grade (i.e. including things like
+            practice problems). You usually want to use
+            ``weighted_graded_possible`` instead of this field.
+        first_attempted (datetime): When did the user first submit a problem'
+            attempt in this subsection?
+        visible_blocks (List[XBlockWithScoringData]): A flat list of XBlock data
+            that represents every scorable component in the subsection for this
+            student at the time that they attempted a problem. Every user may
+            see a slightly different permutation of subsection content depending
+            on various dynamic block types like ``LibraryContentBlock``, as well
+            access rules like cohorts and enrollment tracks. A student can only
+            be graded on what they have access to, so the total possible points
+            for a subsection may vary from student to student. Furthermore, the
+            content can also be edited by the course author after the students
+            have completed the assignment (this is bad practice, but the system
+            allows it). Therefore, the ``visible_blocks`` attribute can give us
+            an audit log of what the content was like at the time that the
+            student was graded.
+        visible_blocks_hash (str): A hash digest for the state of the visible
+            blocks for that user. Changes if anything anything related to
+            the grading information changes, e.g. adding or removing a problem,
+            or changing problem weights.
     """
     user_id = attr.ib(type=int)
     course = attr.ib(type=CourseData)
     subsection_edited_timestamp = attr.ib(type=datetime)
     grading_policy_hash = attr.ib(type=str)
-
     usage_key = attr.ib(type=UsageKey)
 
-    # The "graded" attribute can be set on individual problems if desired, so
-    # this is what's supposed to count towards their progress page/grades. Other
-    # ungraded problems may exist (e.g. practice problems). In practice, this
-    # will almost never happen because marking individual problems as ungraded
-    # requires manually editing XML via import or the advanced editor.
-    # Regardless, if you want to answer the question of, "What did the user earn
-    # for this assignment?", use these fields.
     weighted_graded_earned = attr.ib(type=float)
     weighted_graded_possible = attr.ib(type=float)
-
-    # This represents the earned/possible for all XBlock types that are capable
-    # of holding scoring data in this subsection, regardless of whether they are
-    # marked as "graded" or not, i.e. regardless of whether these points count
-    # towards the student's progress page and final grade. This may have some
-    # obscure use cases, like if for some reason you want to judge mastery based
-    # on an assignment that does not actually count towards the grade of the
-    # course it's in. Overall, this is just here to ensure parity with the
-    # pre-existing event emitted by openedx-platform.
     weighted_total_earned = attr.ib(type=float)
     weighted_total_possible = attr.ib(type=float)
 
     first_attempted = attr.ib(type=datetime)
 
-    # Every user may see a slightly different permutation of subsection content
-    # depending on various dynamic block types like LibraryContentBlock, as well
-    # access rules like cohorts and enrollment tracks. A student can only be
-    # graded on what they have access to, so the total possible grade may vary
-    # from student to student. The visible_blocks attribute captures all the
-    # blocks that were available to this user at the time their subsection grade
-    # was updated.
     visible_blocks = attr.ib(type=List[XBlockWithScoringData])
     visible_blocks_hash = attr.ib(type=str)
 

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -693,3 +693,29 @@ class LtiProviderLaunchData:
     course_key = attr.ib(type=CourseKey)
     usage_key = attr.ib(type=UsageKey)
     launch_params = attr.ib(type=LtiProviderLaunchParamsData)
+
+
+@attr.s(frozen=True)
+class RegistrationDemographicsData:
+    """
+    Attributes defined for Open edX registration demographics object.
+
+    Fired alongside a successful registration when a deployment has
+    enabled an authn-form plugin slot that collects optional demographic
+    information about the learner.
+
+    Both ``pronouns`` and ``department`` default to the empty string so
+    receivers can be written without ``hasattr`` / ``None`` checks; a
+    deployment that has not enabled demographics collection simply never
+    fires the signal at all.
+
+    Arguments:
+        user (UserData): the just-registered user.
+        pronouns (str): free-text pronouns string. Empty if not provided.
+        department (str): department key from the operator-configured
+            allowlist. Empty if not provided.
+    """
+
+    user = attr.ib(type=UserData)
+    pronouns = attr.ib(type=str, default="")
+    department = attr.ib(type=str, default="")

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -4,6 +4,7 @@ Data attributes for events within the architecture subdomain `learning`.
 These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
+
 from datetime import datetime
 from typing import List
 
@@ -290,9 +291,10 @@ class XBlockWithScoringData(XBlockData):
             Specifying weight allows authors to make certain problems worth more
             than others.
     """
-    graded = attr.ib(bool)
-    raw_possible = attr.ib(float)
-    weight = attr.ib(float)
+
+    graded = attr.ib(type=bool)
+    raw_possible = attr.ib(type=float)
+    weight = attr.ib(type=float)
 
 
 @attr.s(frozen=True)
@@ -387,6 +389,7 @@ class PersistentSubsectionGradeData:
             the grading information changes, e.g. adding or removing a problem,
             or changing problem weights.
     """
+
     user_id = attr.ib(type=int)
     course = attr.ib(type=CourseData)
     subsection_edited_timestamp = attr.ib(type=datetime)
@@ -813,6 +816,7 @@ class LtiProviderLaunchParamsData:
         user_id (str): External (LTI) User ID of user performing the launch.
         extra_params (dict): A dictionary of other optional launch parameters.
     """
+
     roles = attr.ib(type=str)
     context_id = attr.ib(type=str)
     user_id = attr.ib(type=str)
@@ -830,6 +834,7 @@ class LtiProviderLaunchData:
         usage_key (UsageKey): The usage key for the content being luanched via LtiProviderLaunchParamsData.
         launch_params (LtiProviderLaunchParamsData): The LTI parameters used for the launch.
     """
+
     user = attr.ib(type=UserData)
     course_key = attr.ib(type=CourseKey)
     usage_key = attr.ib(type=UsageKey)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -839,29 +839,3 @@ class LtiProviderLaunchData:
     course_key = attr.ib(type=CourseKey)
     usage_key = attr.ib(type=UsageKey)
     launch_params = attr.ib(type=LtiProviderLaunchParamsData)
-
-
-@attr.s(frozen=True)
-class RegistrationDemographicsData:
-    """
-    Attributes defined for Open edX registration demographics object.
-
-    Fired alongside a successful registration when a deployment has
-    enabled an authn-form plugin slot that collects optional demographic
-    information about the learner.
-
-    Both ``pronouns`` and ``department`` default to the empty string so
-    receivers can be written without ``hasattr`` / ``None`` checks; a
-    deployment that has not enabled demographics collection simply never
-    fires the signal at all.
-
-    Arguments:
-        user (UserData): the just-registered user.
-        pronouns (str): free-text pronouns string. Empty if not provided.
-        department (str): department key from the operator-configured
-            allowlist. Empty if not provided.
-    """
-
-    user = attr.ib(type=UserData)
-    pronouns = attr.ib(type=str, default="")
-    department = attr.ib(type=str, default="")

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -24,6 +24,7 @@ from openedx_events.learning.data import (
     LtiProviderLaunchData,
     ORASubmissionData,
     PersistentCourseGradeData,
+    PersistentSubsectionGradeData,
     ProgramCertificateData,
     RegistrationDemographicsData,
     UserData,
@@ -204,6 +205,19 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.persistent_grade_summary.changed.v1",
     data={
         "grade": PersistentCourseGradeData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.course.persistent_subsection_grade.changed.v1
+# .. event_name: PERSISTENT_SUBSECTION_GRADE_CHANGED
+# .. event_description: Emitted when a course's persistent grade summary changes for a user.
+# .. event_data: PersistentSubsectionGradeData
+# .. event_trigger_repository: openedx/edx-platform
+PERSISTENT_SUBSECTION_GRADE_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.persistent_subsection_grade.changed.v1",
+    data={
+        "grade": PersistentSubsectionGradeData,
     }
 )
 

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -44,7 +44,7 @@ STUDENT_REGISTRATION_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.student.registration.completed.v1",
     data={
         "user": UserData,
-    }
+    },
 )
 
 
@@ -58,7 +58,7 @@ SESSION_LOGIN_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.auth.session.login.completed.v1",
     data={
         "user": UserData,
-    }
+    },
 )
 
 
@@ -72,7 +72,7 @@ COURSE_ENROLLMENT_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.enrollment.created.v1",
     data={
         "enrollment": CourseEnrollmentData,
-    }
+    },
 )
 
 
@@ -86,7 +86,7 @@ COURSE_ENROLLMENT_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.enrollment.changed.v1",
     data={
         "enrollment": CourseEnrollmentData,
-    }
+    },
 )
 
 
@@ -100,7 +100,7 @@ COURSE_UNENROLLMENT_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.unenrollment.completed.v1",
     data={
         "enrollment": CourseEnrollmentData,
-    }
+    },
 )
 
 
@@ -114,7 +114,7 @@ CERTIFICATE_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.certificate.created.v1",
     data={
         "certificate": CertificateData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.program.certificate.awarded.v1
@@ -127,7 +127,7 @@ PROGRAM_CERTIFICATE_AWARDED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.program.certificate.awarded.v1",
     data={
         "program_certificate": ProgramCertificateData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.certificate.changed.v1
@@ -139,7 +139,7 @@ CERTIFICATE_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.certificate.changed.v1",
     data={
         "certificate": CertificateData,
-    }
+    },
 )
 
 
@@ -153,7 +153,7 @@ CERTIFICATE_REVOKED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.certificate.revoked.v1",
     data={
         "certificate": CertificateData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.program.certificate.revoked.v1
@@ -166,7 +166,7 @@ PROGRAM_CERTIFICATE_REVOKED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.program.certificate.revoked.v1",
     data={
         "program_certificate": ProgramCertificateData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.cohort_membership.changed.v1
@@ -178,7 +178,7 @@ COHORT_MEMBERSHIP_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.cohort_membership.changed.v1",
     data={
         "cohort": CohortData,
-    }
+    },
 )
 
 
@@ -191,9 +191,7 @@ COHORT_MEMBERSHIP_CHANGED = OpenEdxPublicSignal(
 # .. event_trigger_repository: openedx/edx-platform
 COURSE_DISCUSSIONS_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.discussions.configuration.changed.v1",
-    data={
-        "configuration": CourseDiscussionConfigurationData
-    }
+    data={"configuration": CourseDiscussionConfigurationData},
 )
 
 # .. event_type: org.openedx.learning.course.persistent_grade_summary.changed.v1
@@ -205,7 +203,7 @@ PERSISTENT_GRADE_SUMMARY_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.persistent_grade_summary.changed.v1",
     data={
         "grade": PersistentCourseGradeData,
-    }
+    },
 )
 
 
@@ -218,7 +216,7 @@ PERSISTENT_SUBSECTION_GRADE_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.persistent_subsection_grade.changed.v1",
     data={
         "grade": PersistentSubsectionGradeData,
-    }
+    },
 )
 
 
@@ -232,7 +230,7 @@ XBLOCK_SKILL_VERIFIED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.xblock.skill.verified.v1",
     data={
         "xblock_info": XBlockSkillVerificationData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.user.notification.requested.v1
@@ -246,7 +244,7 @@ USER_NOTIFICATION_REQUESTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.user.notification.requested.v1",
     data={
         "notification_data": UserNotificationData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.exam.attempt.submitted.v1
@@ -258,7 +256,7 @@ EXAM_ATTEMPT_SUBMITTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.exam.attempt.submitted.v1",
     data={
         "exam_attempt": ExamAttemptData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.exam.attempt.rejected.v1
@@ -270,7 +268,7 @@ EXAM_ATTEMPT_REJECTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.exam.attempt.rejected.v1",
     data={
         "exam_attempt": ExamAttemptData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.exam.attempt.verified.v1
@@ -282,7 +280,7 @@ EXAM_ATTEMPT_VERIFIED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.exam.attempt.verified.v1",
     data={
         "exam_attempt": ExamAttemptData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.exam.attempt.errored.v1
@@ -294,7 +292,7 @@ EXAM_ATTEMPT_ERRORED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.exam.attempt.errored.v1",
     data={
         "exam_attempt": ExamAttemptData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.exam.attempt.reset.v1
@@ -306,7 +304,7 @@ EXAM_ATTEMPT_RESET = OpenEdxPublicSignal(
     event_type="org.openedx.learning.exam.attempt.reset.v1",
     data={
         "exam_attempt": ExamAttemptData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.user.course_access_role.added.v1
@@ -318,7 +316,7 @@ COURSE_ACCESS_ROLE_ADDED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.user.course_access_role.added.v1",
     data={
         "course_access_role_data": CourseAccessRoleData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.user.course_access_role.removed.v1
@@ -331,7 +329,7 @@ COURSE_ACCESS_ROLE_REMOVED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.user.course_access_role.removed.v1",
     data={
         "course_access_role_data": CourseAccessRoleData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.forum.thread.created.v1
@@ -345,7 +343,7 @@ FORUM_THREAD_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.forum.thread.created.v1",
     data={
         "thread": DiscussionThreadData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.forum.thread.response.created.v1
@@ -359,7 +357,7 @@ FORUM_THREAD_RESPONSE_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.forum.thread.response.created.v1",
     data={
         "thread": DiscussionThreadData,
-    }
+    },
 )
 
 # .. event_type: org.openedx.learning.forum.thread.response.comment.created.v1
@@ -373,7 +371,7 @@ FORUM_RESPONSE_COMMENT_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.forum.thread.response.comment.created.v1",
     data={
         "thread": DiscussionThreadData,
-    }
+    },
 )
 
 
@@ -388,7 +386,7 @@ COURSE_NOTIFICATION_REQUESTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.notification.requested.v1",
     data={
         "course_notification_data": CourseNotificationData,
-    }
+    },
 )
 
 
@@ -415,7 +413,7 @@ COURSE_PASSING_STATUS_UPDATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.passing.status.updated.v1",
     data={
         "course_passing_status": CoursePassingStatusData,
-    }
+    },
 )
 
 
@@ -428,7 +426,7 @@ CCX_COURSE_PASSING_STATUS_UPDATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.ccx.course.passing.status.updated.v1",
     data={
         "course_passing_status": CcxCoursePassingStatusData,
-    }
+    },
 )
 
 
@@ -441,7 +439,7 @@ BADGE_AWARDED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.badge.awarded.v1",
     data={
         "badge": BadgeData,
-    }
+    },
 )
 
 
@@ -454,7 +452,7 @@ BADGE_REVOKED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.badge.revoked.v1",
     data={
         "badge": BadgeData,
-    }
+    },
 )
 
 
@@ -467,7 +465,7 @@ IDV_ATTEMPT_CREATED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.idv_attempt.created.v1",
     data={
         "idv_attempt": VerificationAttemptData,
-    }
+    },
 )
 
 
@@ -480,7 +478,7 @@ IDV_ATTEMPT_PENDING = OpenEdxPublicSignal(
     event_type="org.openedx.learning.idv_attempt.pending.v1",
     data={
         "idv_attempt": VerificationAttemptData,
-    }
+    },
 )
 
 
@@ -493,7 +491,7 @@ IDV_ATTEMPT_APPROVED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.idv_attempt.approved.v1",
     data={
         "idv_attempt": VerificationAttemptData,
-    }
+    },
 )
 
 
@@ -506,7 +504,7 @@ IDV_ATTEMPT_DENIED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.idv_attempt.denied.v1",
     data={
         "idv_attempt": VerificationAttemptData,
-    }
+    },
 )
 
 
@@ -518,7 +516,7 @@ EXTERNAL_GRADER_SCORE_SUBMITTED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.external_grader.score.submitted.v1",
     data={
         "score": ExternalGraderScoreData,
-    }
+    },
 )
 
 
@@ -530,7 +528,7 @@ LTI_PROVIDER_LAUNCH_SUCCESS = OpenEdxPublicSignal(
     event_type="org.openedx.learning.lti_provider.launch.success.v1",
     data={
         "launch_data": LtiProviderLaunchData,
-    }
+    },
 )
 
 

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -26,7 +26,6 @@ from openedx_events.learning.data import (
     PersistentCourseGradeData,
     PersistentSubsectionGradeData,
     ProgramCertificateData,
-    RegistrationDemographicsData,
     UserData,
     UserNotificationData,
     VerificationAttemptData,
@@ -529,17 +528,4 @@ LTI_PROVIDER_LAUNCH_SUCCESS = OpenEdxPublicSignal(
     data={
         "launch_data": LtiProviderLaunchData,
     },
-)
-
-
-# .. event_type: org.openedx.learning.student.registration.demographics.captured.v1
-# .. event_name: REGISTRATION_DEMOGRAPHICS_CAPTURED
-# .. event_description: emitted after STUDENT_REGISTRATION_COMPLETED when an
-#       authn-form plugin slot has collected optional demographic fields.
-# .. event_data: RegistrationDemographicsData
-REGISTRATION_DEMOGRAPHICS_CAPTURED = OpenEdxPublicSignal(
-    event_type="org.openedx.learning.student.registration.demographics.captured.v1",
-    data={
-        "demographics": RegistrationDemographicsData,
-    }
 )

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -25,6 +25,7 @@ from openedx_events.learning.data import (
     ORASubmissionData,
     PersistentCourseGradeData,
     ProgramCertificateData,
+    RegistrationDemographicsData,
     UserData,
     UserNotificationData,
     VerificationAttemptData,
@@ -515,5 +516,18 @@ LTI_PROVIDER_LAUNCH_SUCCESS = OpenEdxPublicSignal(
     event_type="org.openedx.learning.lti_provider.launch.success.v1",
     data={
         "launch_data": LtiProviderLaunchData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.student.registration.demographics.captured.v1
+# .. event_name: REGISTRATION_DEMOGRAPHICS_CAPTURED
+# .. event_description: emitted after STUDENT_REGISTRATION_COMPLETED when an
+#       authn-form plugin slot has collected optional demographic fields.
+# .. event_data: RegistrationDemographicsData
+REGISTRATION_DEMOGRAPHICS_CAPTURED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.student.registration.demographics.captured.v1",
+    data={
+        "demographics": RegistrationDemographicsData,
     }
 )


### PR DESCRIPTION
## Description

(Rebase of #545 )

We already have a [PERSISTENT_GRADE_CHANGED](https://github.com/openedx/openedx-events/blob/fc73ec5dff824c87955fd384359bd01694eedc5f/openedx_events/learning/data.py#L235) event, but we do not have a corresponding event for the subsection.

This mostly borrows the field data already calculated for openedx-platform's [SUBSECTION_GRADE_CALCULATED tracking event](https://github.com/openedx/openedx-platform/blob/497ffae5a75af1344d8e4dfb96a57996a5018c23/lms/djangoapps/grades/events.py#L108-L134).

I don't love the fact that we are putting the model name in the event name (PersistentSubsectionGrade), but I think it's better to be consistent with the already existing convention for emitting the course grade change event.

This event is necessary for CBE work, which will react to these events in order to determine competency at a skill. 

Still needs testing in platform, so in draft.

## Checklists

Check off if complete *or* not applicable:

**Merge Checklist:**
- [ ] All reviewers approved
- [ ] Reviewer tested the code following the testing instructions
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added with short description of the change and current date
- [ ] Documentation updated (not only docstrings)
- [ ] Integration with other services reviewed
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post Merge:**
- [ ] Create a tag
- [ ] Create a release on GitHub
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
- [ ] Upgrade the package in the Open edX platform requirements (if applicable)
