### PR TITLE
chore: release v11.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,16 @@ Change Log
 Unreleased
 __________
 
+[11.2.1] - 2026-07-21
+---------------------
+
+Changed
+~~~~~~~
+
+* Upgraded Python requirements to their latest compatible versions.
+* Pinned GitHub Actions workflows to full commit SHAs.
+* Bumped ``actions/checkout``, ``actions/setup-python``, and ``codecov/codecov-action`` to their latest major versions.
+
 [11.2.0] - 2026-04-20
 ---------------------
 

--- a/openedx_events/__init__.py
+++ b/openedx_events/__init__.py
@@ -5,4 +5,4 @@ These definitions are part of the Hooks Extension Framework, see OEP-50 for
 more information about the project.
 """
 
-__version__ = "11.2.0"
+__version__ = "11.2.1"


### PR DESCRIPTION
## Description
- Bumps version to 11.2.1 (patch release, no new features)
- Adds changelog entry covering the maintenance done since 11.2.0: Python requirements upgrades, GitHub Actions SHA pinning, and dependabot bumps for `actions/checkout`, `actions/setup-python`, and `codecov/codecov-action`
