### PR TITLE
Add openedx-events-2-n8n as example alongside Zapier

### DIFF
--- a/docs/common_refs.rst
+++ b/docs/common_refs.rst
@@ -4,6 +4,8 @@
 .. _Django Signals Documentation: https://docs.djangoproject.com/en/4.2/topics/signals/
 .. _openedx-events-2-zapier: https://github.com/eduNEXT/openedx-events-2-zapier
 .. _Open edX Events To Zapier: https://github.com/eduNEXT/openedx-events-2-zapier
+.. _openedx-events-2-n8n: https://github.com/Abstract-Tech/openedx-events-2-n8n
+.. _Open edX Events To n8n: https://github.com/Abstract-Tech/openedx-events-2-n8n
 
 .. Replaces
 .. |OpenEdxPublicSignal| replace:: :class:`OpenEdxPublicSignal <openedx_events.tooling.OpenEdxPublicSignal>`

--- a/docs/how-tos/consume-an-event.rst
+++ b/docs/how-tos/consume-an-event.rst
@@ -74,7 +74,7 @@ An :term:`Event Receiver` is simply a function that listens for a specific event
 - This event has a single field called ``enrollment``, which is an instance of the ``CourseEnrollmentData`` class. You can review the ``CourseEnrollmentData`` class to understand the data that is available to you and how you can use it to implement the custom logic.
 - The ``metadata`` parameter contains the Open edX-specific metadata for the event, such as the event version and timestamp when the event was sent. You can use this metadata to understand more about the event and its context.
 
-These event receivers are usually implemented independently of the service in an `Open edX Django plugin`_ and are registered in the ``handlers.py`` (according to `OEP-49`_) file of the plugin. You can review the ``handlers.py`` file of the `openedx-events-2-zapier`_ plugin to understand how the event receivers are implemented and connected to the events.
+These event receivers are usually implemented independently of the service in an `Open edX Django plugin`_ and are registered in the ``handlers.py`` (according to `OEP-49`_) file of the plugin. You can review the ``handlers.py`` file of the `openedx-events-2-zapier`_ or `openedx-events-2-n8n`_ plugins to understand how the event receivers are implemented and connected to the events.
 
 Consider the following when implementing the event receiver:
 
@@ -123,7 +123,7 @@ Given the design of Open edX Events, you can include the events' definitions in 
 - In the test suite, you can use the ``send_event`` method to trigger the event and pass the necessary data to the event receiver. In this case, we pass the user, course, and enrollment data to the event receiver as the triggering logic would.
 - After triggering the event, you can assert that the event receiver executed the custom logic as expected. In this case, we check that the request was sent to the webhook with the correct data.
 
-You can review this example to understand how you can test the event receiver and ensure that the custom logic is executed when the event is triggered in the `openedx-events-2-zapier`_ plugin.
+You can review this example to understand how you can test the event receiver and ensure that the custom logic is executed when the event is triggered in the `openedx-events-2-zapier`_ or `openedx-events-2-n8n`_ plugins.
 
 This way you can ensure that the event receiver is working as expected and that the custom logic is executed when the event is triggered. If the event definition or payload changes in any way, you can catch the error in the test suite instead of in production.
 

--- a/docs/quickstarts/use-events-to-call-webhook.rst
+++ b/docs/quickstarts/use-events-to-call-webhook.rst
@@ -8,6 +8,8 @@ Live Example
 
 For a complete and detailed example you can see the `openedx-events-2-zapier`_ plugin and its `documentation`_. This is a fully functional plugin that connects to ``STUDENT_REGISTRATION_COMPLETED`` and ``COURSE_ENROLLMENT_CREATED`` and sends the relevant information to Zapier or any other services.
 
+If you use `n8n`_ instead of Zapier, see the `openedx-events-2-n8n`_ plugin and its `n8n documentation`_, which follows the same integration pattern shown below.
+
 Let's see it working!
 
 Setup Your Environment
@@ -89,6 +91,8 @@ Now that you have configured both :term:`event receivers <Event Receiver>`, you'
 .. _Django plugin: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/README.rst
 .. _documentation: https://edunext.github.io/openedx-events-2-zapier/
 .. _install extra requirements in Tutor: https://docs.tutor.edly.io/configuration.html#installing-extra-xblocks-and-requirements
+.. _n8n: https://n8n.io/
+.. _n8n documentation: https://abstract-tech.github.io/openedx-events-2-n8n/
 
 **Maintenance chart**
 

--- a/docs/reference/real-life-use-cases.rst
+++ b/docs/reference/real-life-use-cases.rst
@@ -111,13 +111,14 @@ More details on: `Forum Emails Notifier`_.
 Webhooks Integration
 ----------------------
 
-`Webhooks`_ trigger an HTTP POST request to a configurable URL when certain events happen in the Open edX platform, including information relevant to the event. When these events are sent, then the data is sent to services like Zapier or any other configured, allowing the sharing of data between different external services.
+`Webhooks`_ trigger an HTTP POST request to a configurable URL when certain events happen in the Open edX platform, including information relevant to the event. When these events are sent, then the data is sent to services like Zapier, n8n, or any other configured, allowing the sharing of data between different external services.
 
 More details on:
 
 * `Webhooks`_.
 * `Open edX Events Sender`_.
 * `Open edX Events To Zapier`_.
+* `Open edX Events To n8n`_.
 
 Send ORA Submissions to Third-Party Plagiarism Services
 ---------------------------------------------------------


### PR DESCRIPTION
Docs mention openedx-events-2-zapier as reference plugin for webhook integrations. We built openedx-events-2-n8n (n8n workflow automation equivalent). 